### PR TITLE
Axis polish

### DIFF
--- a/docs/concepts/scaling.md
+++ b/docs/concepts/scaling.md
@@ -28,17 +28,18 @@ The other two will be discussed under [Usage](#usage).
 
 ### Properties
 
-| Property   | Required | Types           | Default   | Description                                                           |
-| ---------- | -------- | --------------- | --------- | --------------------------------------------------------------------- |
-| domain     | true     | [Array, String] | undefined | Array containing domain boundaries, or a String referencing a column. |
-| type       | false    | String          | depends   | Type of scale.                                                        |
-| domain-min | false    | Number          | undefined | Lower domain boundary. Used to overwrite `domain`.                    |
-| domain-max | false    | Number          | undefined | Upper domain boundary. Used to overwrite `domain`.                    |
-| domain-mid | false    | Number          | undefined | Mid-point of domain. Useful for creating diverging scales.            |
-| range-min  | false    | Number          | undefined | Lower range boundary. Used to overwrite chosen range.                 |
-| range-max  | false    | Number          | undefined | Upper range boundary. Used to overwrite chosen range.                 |
-| absolute   | false    | Boolean         | false     | Will treat negative values as positive.                               |
-| reverse    | false    | Boolean         | true      | Will reverse the order of the scale/domain                            |
+| Property   | Required | Types            | Default   | Description                                                           |
+| ---------- | -------- | ---------------- | --------- | --------------------------------------------------------------------- |
+| domain     | true     | [Array, String]  | undefined | Array containing domain boundaries, or a String referencing a column. |
+| type       | false    | String           | depends   | Type of scale.                                                        |
+| domain-min | false    | Number           | undefined | Lower domain boundary. Used to overwrite `domain`.                    |
+| domain-max | false    | Number           | undefined | Upper domain boundary. Used to overwrite `domain`.                    |
+| domain-mid | false    | Number           | undefined | Mid-point of domain. Useful for creating diverging scales.            |
+| range-min  | false    | Number           | undefined | Lower range boundary. Used to overwrite chosen range.                 |
+| range-max  | false    | Number           | undefined | Upper range boundary. Used to overwrite chosen range.                 |
+| absolute   | false    | Boolean          | false     | Will treat negative values as positive.                               |
+| reverse    | false    | Boolean          | false     | Will reverse the order of the scale/domain                            |
+| nice       | false    | [Boolean, Number]| true      | Extends the domain to start/stop on nice, round values. Can be either a boolean or the desired tick count |
 
 ##### domain
 

--- a/docs/concepts/scaling.md
+++ b/docs/concepts/scaling.md
@@ -38,6 +38,7 @@ The other two will be discussed under [Usage](#usage).
 | range-min  | false    | Number          | undefined | Lower range boundary. Used to overwrite chosen range.                 |
 | range-max  | false    | Number          | undefined | Upper range boundary. Used to overwrite chosen range.                 |
 | absolute   | false    | Boolean         | false     | Will treat negative values as positive.                               |
+| reverse    | false    | Boolean         | true      | Will reverse the order of the scale/domain                            |
 
 ##### domain
 

--- a/src/components/Guides/YAxis.vue
+++ b/src/components/Guides/YAxis.vue
@@ -45,8 +45,8 @@
       >
 
         <vgg-line
-          :x1="midX"
-          :x2="flip ? midX - _tickLength : midX + _tickLength"
+          :x1="flip ? midX + _tickLength : midX - _tickLength"
+          :x2="midX"
           :y1="tick.value"
           :y2="tick.value"
           :stroke="tickColor"
@@ -57,7 +57,7 @@
         <!-- Tick labels -->
         <vgg-label
           v-if="(!labelRotate) && labels"
-          :x="flip ? midX + (_tickLength * 0.3) : midX - (_tickLength * 0.3)"
+          :x="flip ? midX + (_tickLength * 1.2) : midX - (_tickLength * 1.2)"
           :y="tick.value"
           :text="tick.label"
           :font-family="labelFont"
@@ -70,7 +70,7 @@
 
         <vgg-label
           v-if="labelRotate && labels"
-          :x="flip ? midX + (_tickLength * 0.3) : midX - (_tickLength * 0.3)"
+          :x="flip ? midX + (_tickLength * 1.2) : midX - (_tickLength * 1.2)"
           :y="tick.value"
           :text="tick.label"
           :font-family="labelFont"

--- a/src/mixins/Guides/BaseAxis.js
+++ b/src/mixins/Guides/BaseAxis.js
@@ -121,7 +121,7 @@ export default {
 
     tickExtraLabel: {
       type: Boolean,
-      default: false
+      default: true
     },
 
     tickOpacity: {
@@ -276,7 +276,6 @@ export default {
 
         if (this.domainType === 'quantitative') {
           newTickValues = arrayTicks(...this._domain, this.tickCount)
-
           if (this.tickExtra && newTickValues[0] !== firstValue) {
             newTickValues.unshift(firstValue)
           }

--- a/src/scales/utils/parseScaleOptions.js
+++ b/src/scales/utils/parseScaleOptions.js
@@ -102,7 +102,12 @@ function updateDomain (domain, domainType, scalingOptions, dataInterface) {
     }
 
     if (!(is(scalingOptions.domainMin) | is(scalingOptions.domainMax)) & domainType !== 'categorical') {
-      let domainNice = scalingOptions.nice || true
+      // nice domains turned on by default for non-categorical domains
+      // TODO specific logic for temporal domains
+      let domainNice = true
+      if (scalingOptions.nice) {
+        domainNice = scalingOptions.nice
+      }
       if (domainNice === true) {
         newDomain = nice(newDomain, 10)
       }

--- a/src/scales/utils/parseScaleOptions.js
+++ b/src/scales/utils/parseScaleOptions.js
@@ -105,7 +105,7 @@ function updateDomain (domain, domainType, scalingOptions, dataInterface) {
       // nice domains turned on by default for non-categorical domains
       // TODO specific logic for temporal domains
       let domainNice = true
-      if (scalingOptions.nice) {
+      if (is(scalingOptions.nice)) {
         domainNice = scalingOptions.nice
       }
       if (domainNice === true) {

--- a/src/scales/utils/parseScaleOptions.js
+++ b/src/scales/utils/parseScaleOptions.js
@@ -102,6 +102,11 @@ function updateDomain (domain, domainType, scalingOptions, dataInterface) {
       newDomain[1] = scalingOptions.domainMax
     }
 
+    if (is(scalingOptions.reverse)) {
+      if (scalingOptions.reverse === true) {
+        newDomain.reverse()
+      }
+    }
     return newDomain
   } else { return domain }
 }

--- a/src/scales/utils/parseScaleOptions.js
+++ b/src/scales/utils/parseScaleOptions.js
@@ -61,9 +61,7 @@ export default function (passedScaleOptions, dataInterface, scaleManager) {
 
     domainType = getDataType(domain[0])
   }
-
   domain = updateDomain(domain, domainType, scaleOptions)
-
   return [domain, domainType, scaleOptions]
 }
 
@@ -93,7 +91,7 @@ function checkValidDomainArray (array) {
 
 function updateDomain (domain, domainType, scalingOptions, dataInterface) {
   if (validScalingOptions(domainType, scalingOptions)) {
-    let newDomain = [domain[0], domain[1]]
+    let newDomain = domain.slice()
 
     if (is(scalingOptions.domainMin)) {
       newDomain[0] = scalingOptions.domainMin
@@ -128,7 +126,7 @@ function validScalingOptions (domainType, scalingOptions) {
     if (hasAnyWrongProperty(scalingOptions)) {
       throw new Error(`Invalid scaling options for categorical domain: ${JSON.stringify(scalingOptions)}`)
     }
-    return false
+    return true
   } else {
     checkTypes(domainType, scalingOptions)
     return true


### PR DESCRIPTION
- Added a `reverse` prop to `scales` to easily invert the domain. Useful to change plotting order, for example, from top-to-bottom to bottom-to-top etc.
- Y axis tick marks now default to the left of the 'baseline'. Not sure if there was a particular reason to default to the right but this is counter to most other visualization software.
![image](https://user-images.githubusercontent.com/1752727/54494009-ce3e3b00-4910-11e9-84c8-c56b3ba789b7.png)
- Added a `nice` prop to `scales` so domain can be extended to include a 'nice' minimum and maximum. This is particularly useful to create a useful, round first tick mark (this was previously an oddly spaced tick mark with, if displayed, often a 'weird' (to the user) label. With 'nice' domains:
![image](https://user-images.githubusercontent.com/1752727/54494073-80760280-4911-11e9-9657-0c108124d624.png)