### PR TITLE
fix: plot title positioning error

### DIFF
--- a/src/components/Elements/PlotTitle.vue
+++ b/src/components/Elements/PlotTitle.vue
@@ -71,7 +71,7 @@ export default {
       let xMax = Math.max(xRange[0], xRange[1])
 
       if (this.hjust.constructor === Number) {
-        let scaledVal = (xMax - xMin) * this.vjust
+        let scaledVal = (xMax - xMin) * this.hjust + xMin
         return scaledVal
       } else if (this.hjust === 'center') {
         return (xMax - xMin) / 2 + xRange[0]
@@ -89,7 +89,7 @@ export default {
       let yMax = Math.max(yRange[0], yRange[1])
 
       if (this.vjust.constructor === Number) {
-        let scaledVal = (yMax - yMin) * this.hjust
+        let scaledVal = (yMax - yMin) * this.vjust + yMin
         return scaledVal
       } else if (this.vjust === 'center') {
         return (yMax - yMin) / 2 + yMin

--- a/stories/sandbox/Facets.vue
+++ b/stories/sandbox/Facets.vue
@@ -43,6 +43,11 @@
             ]"
           >
 
+            <vgg-plot-title
+              :text="facet.town"
+              :vjust="1"
+            />
+
             <vgg-map v-slot="{ row }">
 
               <vgg-rectangle

--- a/stories/sandbox/RepeatLayout.vue
+++ b/stories/sandbox/RepeatLayout.vue
@@ -24,6 +24,13 @@
         }"
       >
 
+        <vgg-plot-title
+          :margin="0"
+          :v-margin="-20"
+          text="Subsection"
+          hjust="l"
+        />
+
         <vgg-map v-slot="{ row }">
 
           <vgg-point

--- a/stories/sandbox/SectionAxesTest.vue
+++ b/stories/sandbox/SectionAxesTest.vue
@@ -18,6 +18,12 @@
           :grid-lines="['x']"
         >
 
+          <vgg-plot-title
+            :margin="0"
+            :v-margin="-20"
+            text="Subsection"
+          />
+
           <vgg-map v-slot="{ row }">
 
             <vgg-point


### PR DESCRIPTION
`vgg-plot-title` can now be used in facets/subsections with proper positioning.

![image](https://user-images.githubusercontent.com/16433058/54969962-46fd6100-4fbb-11e9-833f-fcfdcb4465e6.png)
