### PR TITLE
Axis ticks fix + Binning defaults

### DIFF
--- a/docs/transform/binning.md
+++ b/docs/transform/binning.md
@@ -9,8 +9,7 @@ title: Binning
 ```
 
 The `binning` operation is like the `groupBy` operation, except with quantitative
-data. Also, while `groupBy` keeps the name of the variable(s) that the data were grouped
-by, binning will create a new column named `bins`. It is only possible to bin based
+data. Also, while `groupBy` keeps the name of the variable(s) that was used to group the data, binning will create a new column named `bins`. It is only possible to bin based
 on one column.
 
 ## Instructions
@@ -24,10 +23,10 @@ on one column.
 The binning transformation takes an object specifying the parameters of the binning method used,
 and returns a new dataframe with two columns:
 
-1. a column called `'bins'`, that contains the upper and lower boundaries of the
-bins as [interval](../concepts/data-loading#data-types) data.
+1. a column called `'bins'`, that contains the `[lowerbound, upperbound]` of the
+bins as [interval](../concepts/data-loading#data-types) data type.
 2. a column called `'grouped'`, that contains the data that is inside of each
-bin as [nested](../concepts/data-loading#data-types) data.
+bin as [nested](../concepts/data-loading#data-types) data type.
 
 ## Keys
 
@@ -37,67 +36,97 @@ bin as [nested](../concepts/data-loading#data-types) data.
 
 All binning transformations must specify the following keys:
 
-Key       | Type      |  Description
-----------|-----------|----------------------------
-groupBy   | String    | Name of data variable on which to perform binning
-method    | String    | Type of binning to perform
+Key       | Required  | Default         | Type      |  Description
+----------|-----------|-----------------|-----------|----------------------------
+groupBy   | true      | undefined       | String    | Name of data variable on which to perform binning
+method    | false     | 'EqualInterval' | String    | Method of binning to use
 
-Furthermore, different binning `method`s have additional required keys.
-These different `method`s, and their additional required keys, will be discussed
-below.
+## Additional Method Keys
 
-Here is an example using the `EqualInterval` method, which has the additional
-required `numClasses` key:
-
-::: v-pre
-```html
-<vgg-data
-  :data="{ a: [1, 2, 3, 4, 5, 6, 7], b: [8, 9, 10, 11, 12, 13, 14] }"
-  :transform="{ binning: { groupBy: 'a', method: 'EqualInterval', numClasses: 3 } }"
->
-
-  <!-- Data scope: {
-    bins: [[1, 3], [3, 5], [5, 7]],
-    grouped: [
-      { a: [1, 2, 3], b: [8, 9, 10] },
-      { a: [4, 5], b: [11, 12] },
-      { a: [6, 7], b: [13, 14] }
-    ]
-  } -->
-
-</vgg-data>
-```
-:::
+Different binning methods may require additional keys.
 
 ### IntervalSize
 
 The `IntervalSize` method groups data into bins of a given size.
 
-Key       | Type      |  Description
-----------|-----------|----------------------------
-binSize   | Number    | Size of each bin
+Key       | Required  | Default         | Type      |  Description
+----------|-----------|-----------------|-----------|----------------------------
+binSize   | false     | 1               | Number    | Size of each bin
+
+::: v-pre
+```html{3-4}
+<vgg-data
+  :data="{ a: [1, 2, 3, 4, 5, 6, 7], b: [8, 9, 10, 11, 12, 13, 14] }"
+  :transform="{ binning: { groupBy: 'a',
+                           method: 'IntervalSize', binSize: 3 } }"
+>
+```
+:::
+
+bins      | grouped                                    |
+----------|--------------------------------------------|
+[1, 4]    | { a: [1, 2, 3, 4], b: [8, 9, 10, 11] }     |
+[4, 7]    | { a: [5, 6], b: [12, 13] }                 |
 
 ### EqualInterval
 
 The `EqualInterval` method groups data into a given number of equal sized bins.
 
-Key       | Type      |  Description
-----------|-----------|----------------------------
-numClasses| Number    | Number of bins
+Key       | Required  | Default         | Type      |  Description
+----------|-----------|-----------------|-----------|----------------------------
+numClasses| false     | 5               | Number    | Number of bins
 
-### StandardDeviation, ArithmeticProgression, Geometric Progression, Quantile, Jenks
+::: v-pre
+```html{3-4}
+<vgg-data
+  :data="{ a: [1, 2, 3, 4, 5, 6, 7], b: [8, 9, 10, 11, 12, 13, 14] }"
+  :transform="{ binning: { groupBy: 'a',
+                           method: 'EqualInterval', numClasses: 3 } }"
+>
+```
+:::
 
-These classification methods are made available through [geostats](https://github.com/simogeo/geostats)
-(see geostats docs for details on each method).
+bins      | grouped                             |
+----------|-------------------------------------|
+[1, 3]    | { a: [1, 2, 3], b: [8, 9, 10] }     |
+[3, 5]    | { a: [4, 5], b: [11, 12] }          |
+[5, 7]    | { a: [6, 7], b: [13, 14] }          |
 
-Key       | Type      |  Description
-----------|-----------|----------------------------
-numClasses| Number    | Number of bins
+### StandardDeviation | ArithmeticProgression | Geometric Progression | Quantile | Jenks
+
+These classification methods are adapted from [geostats](https://github.com/simogeo/geostats) and share a similar syntax.
+
+Key       | Required  | Default         | Type      |  Description
+----------|-----------|-----------------|-----------|----------------------------
+numClasses| false     | 5               | Number    | Number of bins
+
+::: v-pre
+```html{3-4}
+<vgg-data
+  :data="{ a: [1, 2, 3, 4, 5, 6, 7], b: [8, 9, 10, 11, 12, 13, 14] }"
+  :transform="{ binning: { groupBy: 'a',
+                           method: 'StandardDeviation', numClasses: 3 } }"
+>
+```
 
 ### Manual
 
 The `Manual` method groups data into user-defined ranges.
 
-Key          | Type      |  Description
--------------|-----------|----------------------------
-manualClasses| Array     | An array of bin boundaries
+Key          | Required  | Default         | Type      |  Description
+-------------|-----------|-----------------|-----------|----------------------------
+manualClasses| true      | undefined       | Array     | An array of bin boundaries
+
+::: v-pre
+```html{3-4}
+<vgg-data
+  :data="{ a: [1, 2, 3, 4, 5, 6, 7], b: [8, 9, 10, 11, 12, 13, 14] }"
+  :transform="{ binning: { groupBy: 'a',
+                           method: 'Manual', manualClasses: [1, 5, 7] } }"
+>
+```
+
+bins      | grouped                                           |
+----------|---------------------------------------------------|
+[1, 5]    | { a: [1, 2, 3, 4, 5], b: [8, 9, 10, 11, 12] }     |
+[5, 7]    | { a: [6, 7], b: [13, 14] }                 |

--- a/src/components/Guides/XAxis.vue
+++ b/src/components/Guides/XAxis.vue
@@ -234,6 +234,6 @@ export default {
     parsedScale () {
       return createScale('x', this.context, this.scale)
     }
-  },
+  }
 }
 </script>

--- a/src/components/Guides/XAxis.vue
+++ b/src/components/Guides/XAxis.vue
@@ -200,6 +200,10 @@ export default {
       return this.axisCoords.y1 + (this.widthY / 2)
     },
 
+    valueRange () {
+      return [this.axisCoords.x1, this.axisCoords.x2]
+    },
+
     titleCoords () {
       let coords = {}
 
@@ -230,6 +234,6 @@ export default {
     parsedScale () {
       return createScale('x', this.context, this.scale)
     }
-  }
+  },
 }
 </script>

--- a/src/components/Guides/YAxis.vue
+++ b/src/components/Guides/YAxis.vue
@@ -200,6 +200,10 @@ export default {
       return this.axisCoords.x1 + (this.widthX / 2)
     },
 
+    valueRange () {
+      return [this.axisCoords.y1, this.axisCoords.y2]
+    },
+
     titleCoords () {
       let coords = {}
 

--- a/src/mixins/Guides/BaseAxis.js
+++ b/src/mixins/Guides/BaseAxis.js
@@ -1,5 +1,5 @@
 import { ticks as arrayTicks } from 'd3-array'
-import { scaleTime } from 'd3-scale'
+import { scaleTime, scaleLinear } from 'd3-scale'
 import { timeFormat } from 'd3-time-format'
 
 import Rectangular from '../Marks/Rectangular.js'
@@ -106,7 +106,7 @@ export default {
 
     tickCount: {
       type: Number,
-      default: 10
+      default: undefined
     },
 
     tickColor: {
@@ -263,19 +263,17 @@ export default {
       if (this.tickValues) {
         newTickValues = this.tickValues
 
-        if (this.tickExtra && this.tickValues[0] !== firstValue) {
-          newTickValues.unshift(firstValue)
-        }
+        let format = this.format && this.format.constructor === Function ? this.format : defaultFormat
 
         return newTickValues.map(value => {
-          return { value }
-        })
+                 return { value: this.parsedScale(value), label: format(value) } })
       } else {
         let ticks
         let format = this.format && this.format.constructor === Function ? this.format : defaultFormat
 
         if (this.domainType === 'quantitative') {
-          newTickValues = arrayTicks(...this._domain, this.tickCount)
+          let numTicks = this.tickCount ? this.tickCount : 10
+          newTickValues = arrayTicks(...this._domain, numTicks)
           if (this.tickExtra && newTickValues[0] !== firstValue) {
             newTickValues.unshift(firstValue)
           }
@@ -293,6 +291,11 @@ export default {
           ticks = this._domain.map(value => {
             return { value, label: format(value) }
           })
+
+          if (this.tickCount) {
+            let step = Math.floor(ticks.length / this.tickCount)
+            ticks = ticks.filter((value, i) => (i % step) === 0)
+          }
         }
 
         if (this.domainType === 'temporal') {
@@ -326,6 +329,11 @@ export default {
           ticks = ticksFromIntervals(intervals).map(value => {
             return { value, label: format(value) }
           })
+
+          if (this.tickCount) {
+            let step = Math.floor(ticks.length / this.tickCount)
+            ticks = ticks.filter((value, i) => (i % step) === 0)
+          }
         }
 
         if (this.domainType === 'interval:temporal') {
@@ -340,6 +348,11 @@ export default {
             let date = new Date(value)
             return { value: date, label: format(date) }
           })
+
+          if (this.tickCount) {
+            let step = Math.floor(ticks.length / this.tickCount)
+            ticks = ticks.filter((value, i) => (i % step) === 0)
+          }
         }
 
         return ticks.map(tick => {
@@ -353,6 +366,6 @@ export default {
   methods: {
     getJust (lowerBound, width, just) {
       return lowerBound + (width * just)
-    }
+    },
   }
 }

--- a/src/mixins/Guides/BaseAxis.js
+++ b/src/mixins/Guides/BaseAxis.js
@@ -1,5 +1,5 @@
 import { ticks as arrayTicks } from 'd3-array'
-import { scaleTime, scaleLinear } from 'd3-scale'
+import { scaleTime } from 'd3-scale'
 import { timeFormat } from 'd3-time-format'
 
 import Rectangular from '../Marks/Rectangular.js'
@@ -266,7 +266,8 @@ export default {
         let format = this.format && this.format.constructor === Function ? this.format : defaultFormat
 
         return newTickValues.map(value => {
-                 return { value: this.parsedScale(value), label: format(value) } })
+          return { value: this.parsedScale(value), label: format(value) }
+        })
       } else {
         let ticks
         let format = this.format && this.format.constructor === Function ? this.format : defaultFormat
@@ -366,6 +367,6 @@ export default {
   methods: {
     getJust (lowerBound, width, just) {
       return lowerBound + (width * just)
-    },
+    }
   }
 }

--- a/src/transformations/transformations/binning.js
+++ b/src/transformations/transformations/binning.js
@@ -67,7 +67,7 @@ export default function (data, binningObj) {
   }
 
   ranges = pairRange(ranges)
-  
+
   let newData = bin(data, key, ranges)
   return newData
 }

--- a/src/transformations/transformations/binning.js
+++ b/src/transformations/transformations/binning.js
@@ -12,13 +12,25 @@ export default function (data, binningObj) {
   }
 
   let method = binningObj.method
+  if (!method) {
+    console.warn('No binning method specified, defaulting to EqualInterval')
+    method = 'EqualInterval'
+  }
   if (method.constructor !== String) {
-    throw new Error('Please provide the classification method you will like to use')
+    console.warn('Binning method not recognized, defaulting to EqualInterval')
+    method = 'EqualInterval'
   }
 
   let numClasses = binningObj.numClasses
+  if (!numClasses) {
+    console.warn('numClasses not specified, defaulting to 5')
+    numClasses = 5
+  }
 
   let variableData = data[key]
+  if (!variableData) {
+    throw new Error(`groupBy variable ${key} does not exist`)
+  }
   // let geoStat = new Geostats(variableData)
   let geoStat = new Geostats(variableData)
 
@@ -27,10 +39,17 @@ export default function (data, binningObj) {
   // Calculate ranges to obtain bins of a specified size
   if (method === 'IntervalSize') {
     let binSize = binningObj.binSize
+
     let domain = variableDomain(variableData)
+    if (!binSize) {
+      console.warn(`binSize not specified for IntervalSize binning, defaulting to ${(domain[1] - domain[0])}`)
+      binSize = domain[1] - domain[0]
+    }
     let binCount = Math.round((domain[1] - domain[0]) / binSize)
 
     ranges = rangeFromInterval(domain, binSize, binCount)
+    let newData = bin(data, key, ranges)
+    return newData
   } else if (method === 'EqualInterval') {
     ranges = geoStat.getClassEqInterval(numClasses)
   } else if (method === 'StandardDeviation') {
@@ -48,7 +67,7 @@ export default function (data, binningObj) {
   }
 
   ranges = pairRange(ranges)
-
+  
   let newData = bin(data, key, ranges)
   return newData
 }
@@ -83,7 +102,6 @@ function rangeFromInterval (domain, interval, binCount) {
 
 function pairRange (ranges) {
   let l = ranges.length
-
   let newRange = []
 
   for (let i = 0; i < l - 1; i++) {

--- a/stories/sandbox/BarChart.vue
+++ b/stories/sandbox/BarChart.vue
@@ -74,8 +74,11 @@
         :scale="'fruit'"
         :title-hjust="1.1"
         :vjust="-.05"
+        :tickCount="5"
         label-rotate
       />
+
+      <!-- :tick-values="['apple', 'guava', 'pomelo']" -->
 
       <vgg-y-axis
         :scale="{ domain: 'quantity', domainMin: 0 }"

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <select v-model="selected">
-      <option value="EqualInterval">Equal Interval</option>
+      <option value="">Equal Interval</option>
       <option value="ArithmeticProgression">Arithmetic Progression</option>
       <option value="GeometricProgression">Geometric Progression</option>
       <option value="Quantile">Quantile</option>
@@ -48,39 +48,21 @@
 
           </vgg-map>
 
-          <!-- <vgg-x-axis
-            scale="bins"
-            :titleHjust="1.1"
-            :vjust="-.05"
-            rotate-label
-          />
+          <vgg-x-grid :scale="'bins'" />
 
           <vgg-y-axis
             :scale="{ domain: 'binCount', domainMin: 0 }"
-            :hjust="-.05"
-            flip
-          /> -->
+            :tick-count="5"
+            :hjust="-0.05"
+          />
 
-          <vgg-x-grid :scale="'bins'" />
+          <vgg-x-axis
+            scale="bins"
+            :tick-values="[0, 50, 80]"
+            :vjust="-0.05"
+          />
 
         </vgg-section>
-
-        <vgg-x-axis
-          :x1="100"
-          :x2="500"
-          :y1="50"
-          :y2="100"
-          scale="bins"
-          rotate-label
-        />
-
-        <vgg-y-axis
-          :x1="500"
-          :x2="550"
-          :y1="100"
-          :y2="500"
-          :scale="{ domain: 'binCount', domainMin: 0 }"
-        />
 
       </vgg-data>
 
@@ -99,7 +81,7 @@ export default {
         c: this.generate(100),
         d: this.generate(100)
       },
-      selected: 'EqualInterval'
+      selected: ''
     }
   },
   computed: {

--- a/stories/sandbox/Scatterplot.vue
+++ b/stories/sandbox/Scatterplot.vue
@@ -32,29 +32,13 @@
           :scale="'explanatory'"
           :title-hjust="1.1"
           :vjust="-.05"
+          :tick-values="[0, 20, 60, 100]"
         />
 
         <vgg-y-axis
           :scale="'dependent'"
           :hjust="-.05"
-          flip
         />
-
-        <!-- <vgg-y-axis
-          :x1="500"
-          :x2="550"
-          :y1="100"
-          :y2="500"
-          :scale="'dependent'"
-        />
-
-        <vgg-x-axis
-          :x1="100"
-          :x2="500"
-          :y="75"
-          :h="30"
-          :scale="'explanatory'"
-        /> -->
 
       </vgg-section>
 


### PR DESCRIPTION
Fix for #98 

Changes in this PR:

binning defaults
- binning transformation now has default `method` and `numClasses` values
- console warning is issued when using defaults
- updated binning docs to reflect this change

`tick-values` prop fixed
- now works for both `quantitative` and `categorical` datatypes
- (see storybook sandbox scatterplot and barchart)
- labels display as expected

expanded `tick-count` functionality
- this is to address the messy bin ticks issue. I made the `tick-count` prop apply to all datatypes so users can just do this:
```
<vgg-x-axis scale="bins" :tick-count="5" />
```

@luucvanderzee I decided to hold off on implementing a new `nice` prop since we already have `tick-count`. What do you think? 