### PR TITLE
Grid accept custom components

### DIFF
--- a/docs/core/grid.md
+++ b/docs/core/grid.md
@@ -8,8 +8,11 @@ title: 'Grid'
 
 # Description
 
-The Grid component is used to quickly position and align [Section](./section.md)
-components in a grid format.
+The Grid component is used to quickly position and align 'square'
+components in a grid format. 'Square' here refers to any component that has
+ `x1`, `x2`, `y1` and `y2` props. This includes the [Section](./section.md)
+ component, the [Rectangle](../marks/rectangle.md) mark, and any custom component
+ that you would want to create, given it has the props mentioned above.
 
 # Props
 
@@ -19,7 +22,7 @@ components in a grid format.
 | cols           | depends  | Number           | undefined | Max. number olf columns the grid can have    |
 | layout-padding | false    | [Number, Object] | 0         | Padding with respect to parent element       |
 | cell-padding   | false    | [Number, Object] | 0         | Padding between child elements               |
-| start          | false    | String           | 'b'       | Start filling from top ('t') or bottom ('b') | 
+| start          | false    | String           | 'b'       | Start filling from top ('t') or bottom ('b') |
 
 The Grid component requires either the `rows`, _or_ the `cols` prop. If you use both,
 or neither, the component will throw an error. The number given to `rows` or `cols`

--- a/docs/core/repeat.md
+++ b/docs/core/repeat.md
@@ -8,8 +8,11 @@ title: 'Repeat'
 
 # Description
 
-The Repeat component is used to quickly position and align [Section](./section.md)
-components in a 2d matrix format.
+The Repeat component is used to quickly position and align 'square' components
+in a 2d matrix format. 'Square' here refers to any component that has
+ `x1`, `x2`, `y1` and `y2` props. This includes the [Section](./section.md)
+ component, the [Rectangle](../marks/rectangle.md) mark, and any custom component
+ that you would want to create, given it has the props mentioned above.
 
 # Props
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "d3-scale-chromatic": "^1.3.3",
     "d3-shape": "^1.2.2",
     "d3-time-format": "^2.1.3",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "proj4": "^2.5.0",
     "rbush": "^2.0.2",

--- a/src/components/Core/Grid.vue
+++ b/src/components/Core/Grid.vue
@@ -5,6 +5,7 @@ import {
   validateGridOptions,
   updateGridComponents
 } from './utils/grid.js'
+import isSquareComponent from './utils/isSquareComponent.js'
 import CoordinateTreeUser from '../../mixins/CoordinateTreeUser.js'
 import DataReceiver from '../../mixins/Data/DataReceiver.js'
 
@@ -63,16 +64,7 @@ export default {
   },
 
   methods: {
-    isSquareComponent (component) {
-      let props = component.componentOptions.Ctor.options.props
-      let squareProps = ['x1', 'x2', 'y1', 'y2']
-      for (let prop of squareProps) {
-        if (!props[prop]) {
-          return false
-        }
-      }
-      return true
-    }
+    isSquareComponent
   },
 
   provide () {

--- a/src/components/Core/Map.vue
+++ b/src/components/Core/Map.vue
@@ -2,6 +2,7 @@
 import DataReceiver from '../../mixins/Data/DataReceiver.js'
 import CoordinateTreeUser from '../../mixins/CoordinateTreeUser.js'
 import ScaleReceiver from '../../mixins/Scales/ScaleReceiver.js'
+import isSquareComponent from './utils/isSquareComponent.js'
 
 import {
   calculateGridLayout,
@@ -84,16 +85,7 @@ export default {
       }
     },
 
-    isSquareComponent (component) {
-      let props = component.componentOptions.Ctor.options.props
-      let squareProps = ['x1', 'x2', 'y1', 'y2']
-      for (let prop of squareProps) {
-        if (!props[prop]) {
-          return false
-        }
-      }
-      return true
-    }
+    isSquareComponent
   },
 
   provide () {

--- a/src/components/Core/Repeat.vue
+++ b/src/components/Core/Repeat.vue
@@ -1,6 +1,6 @@
 <script>
 import { calculateGridLayout } from './utils/grid.js'
-import { calculateRowsCols, repeatSections } from './utils/repeat.js'
+import { calculateRowsCols, repeatComponents } from './utils/repeat.js'
 import CoordinateTreeUser from '../../mixins/CoordinateTreeUser.js'
 
 export default {
@@ -56,7 +56,7 @@ export default {
     let sides = this.sides
 
     let slot = this.$scopedSlots.default
-    let newSections = repeatSections(createElement, slot, layout, this.x, this.y, sides)
+    let newSections = repeatComponents(slot, layout, this.x, this.y, sides)
 
     return createElement('g', { class: 'layout-repeat' }, newSections)
   }

--- a/src/components/Core/utils/grid.js
+++ b/src/components/Core/utils/grid.js
@@ -1,5 +1,3 @@
-import Section from '../Section.vue'
-
 export function validateGridOptions (options) {
   let hasRows = options.rows !== undefined
   let hasCols = options.cols !== undefined
@@ -74,15 +72,15 @@ export function calculateGridLayout (rows, cols, options, ranges, axes, start) {
   return cells
 }
 
-export function updateGridSections (createElement, sections, gridLayout) {
-  let newSections = []
-  for (let i = 0; i < sections.length; i++) {
-    let section = sections[i]
+export function updateGridComponents (components, gridLayout) {
+  let newComponents = []
+  for (let i = 0; i < components.length; i++) {
+    let component = components[i]
     let layout = gridLayout[i]
-    newSections.push(updateSection(createElement, section, layout))
+    newComponents.push(updateComponent(component, layout))
   }
 
-  return newSections
+  return newComponents
 }
 
 function getPadding (padding) {
@@ -106,11 +104,11 @@ function getPadding (padding) {
   return paddings
 }
 
-export function updateSection (createElement, section, layout) {
-  let props = mergeProps(layout, section.componentOptions.propsData)
-  let slots = section.componentOptions.children
-  let newSection = createElement(Section, { props }, slots)
-  return newSection
+export function updateComponent (component, layout) {
+  let clonedComponent = component
+  let props = mergeProps(layout, component.componentOptions.propsData)
+  clonedComponent.componentOptions.propsData = props
+  return clonedComponent
 }
 
 function mergeProps (coords, other) {

--- a/src/components/Core/utils/isSquareComponent.js
+++ b/src/components/Core/utils/isSquareComponent.js
@@ -1,0 +1,10 @@
+export default function (component) {
+  let props = component.componentOptions.Ctor.options.props
+  let squareProps = ['x1', 'x2', 'y1', 'y2']
+  for (let prop of squareProps) {
+    if (!props[prop]) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/components/Core/utils/repeat.js
+++ b/src/components/Core/utils/repeat.js
@@ -1,4 +1,4 @@
-import { updateSection } from './grid.js'
+import { updateComponent } from './grid.js'
 
 export function repeatSections (createElement, slot, layout, xValues, yValues, sides) {
   let newSections = []
@@ -18,7 +18,7 @@ export function repeatSections (createElement, slot, layout, xValues, yValues, s
       let currentLayout = layout[layoutIndex]
 
       let updatedSections = sections.map(section => {
-        return updateSection(createElement, section, currentLayout)
+        return updateComponent(section, currentLayout)
       })
 
       let currentSides = getSides(rowIndex, colIndex, rowLength, colLength)

--- a/src/components/Core/utils/repeat.js
+++ b/src/components/Core/utils/repeat.js
@@ -1,7 +1,8 @@
 import { updateComponent } from './grid.js'
+import isSquareComponent from './isSquareComponent.js'
 
-export function repeatSections (createElement, slot, layout, xValues, yValues, sides) {
-  let newSections = []
+export function repeatComponents (slot, layout, xValues, yValues, sides) {
+  let newComponents = []
 
   let rowLength = yValues.length
   let colLength = xValues.length
@@ -12,26 +13,26 @@ export function repeatSections (createElement, slot, layout, xValues, yValues, s
       let x = xValues[colIndex]
 
       let slotContent = slot({ x, y })
-      let sections = validateSlotContent(slotContent)
+      let components = validateSlotContent(slotContent)
 
       let layoutIndex = (rowIndex * colLength) + colIndex
       let currentLayout = layout[layoutIndex]
 
-      let updatedSections = sections.map(section => {
+      let updatedComponents = components.map(section => {
         return updateComponent(section, currentLayout)
       })
 
       let currentSides = getSides(rowIndex, colIndex, rowLength, colLength)
 
-      updatedSections = updatedSections.map(section => {
+      updatedComponents = updatedComponents.map(section => {
         return hideSectionAxes(section, currentSides, sides)
       })
 
-      newSections.push(...updatedSections)
+      newComponents.push(...updatedComponents)
     }
   }
 
-  return newSections
+  return newComponents
 }
 
 export function calculateRowsCols (x, y) {
@@ -52,8 +53,8 @@ export function createAxesProps (axis, axisOptions, range, repeatVals) {
 
 function validateSlotContent (slotContent) {
   let definedElements = slotContent.filter(c => c.tag !== undefined)
-  if (definedElements.some(c => c.componentOptions.tag !== 'vgg-section')) {
-    throw new Error(`vgg-repeat can only contain sections`)
+  if (definedElements.some(c => !isSquareComponent(c))) {
+    throw new Error(`vgg-repeat can only contain 'square' components`)
   }
   return definedElements
 }

--- a/stories/sandbox/CustomSquareComponent.vue
+++ b/stories/sandbox/CustomSquareComponent.vue
@@ -1,0 +1,53 @@
+<template>
+  <vgg-section
+    :x1="x1"
+    :x2="x2"
+    :y1="y1"
+    :y2="y2"
+    :scale-x="[0, 1]"
+    :scale-y="[0, 1]"
+  >
+
+    <vgg-point
+      :x="0.5"
+      :y="0.5"
+    />
+
+    <vgg-rectangle
+      :x1="0"
+      :x2="1"
+      :y1="0"
+      :y2="1"
+      :fill="fill"
+    />
+
+  </vgg-section>
+
+</template>
+
+<script>
+export default {
+  props: {
+    x1: {
+      type: Number,
+      required: true
+    },
+    x2: {
+      type: Number,
+      required: true
+    },
+    y1: {
+      type: Number,
+      required: true
+    },
+    y2: {
+      type: Number,
+      required: true
+    },
+    fill: {
+      type: String,
+      default: 'black'
+    }
+  }
+}
+</script>

--- a/stories/sandbox/RepeatLayout.vue
+++ b/stories/sandbox/RepeatLayout.vue
@@ -42,6 +42,7 @@
         </vgg-map>
 
       </vgg-section>
+      <!-- <vgg-rectangle /> -->
 
     </vgg-repeat>
 

--- a/stories/sandbox/SimpleGridLayout.vue
+++ b/stories/sandbox/SimpleGridLayout.vue
@@ -10,7 +10,7 @@
       :cell-padding="{ l: 7, r: 20, b: 4 }"
     >
 
-      <vgg-section
+      <!-- <vgg-section
         v-for="s in range(5)"
         :key="s"
         :scale-x="[0, 1]"
@@ -25,7 +25,12 @@
           :fill="randomColor()"
         />
 
-      </vgg-section>
+      </vgg-section> -->
+      <vgg-rectangle
+        v-for="s in range(s)"
+        :key="s"
+        :fill="randomColor()"
+      />
 
     </vgg-grid>
 

--- a/stories/sandbox/SimpleGridLayout.vue
+++ b/stories/sandbox/SimpleGridLayout.vue
@@ -26,8 +26,8 @@
         />
 
       </vgg-section> -->
-      <vgg-rectangle
-        v-for="s in range(s)"
+      <custom-square-component
+        v-for="s in range(5)"
         :key="s"
         :fill="randomColor()"
       />
@@ -38,7 +38,11 @@
 </template>
 
 <script>
+import CustomSquareComponent from './CustomSquareComponent.vue'
+
 export default {
+  components: { CustomSquareComponent },
+
   methods: {
     range (n) {
       return new Array(n).fill(0).map((v, i) => i)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5549,6 +5549,7 @@ lodash.camelcase@^4.3.0:
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.debounce@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
By request: allow the `vgg-grid` to accept any type of 'square' component, meaning any component that has `x1`, `x2`, `y1` and `y2` props.

Also works for `vgg-repeat`!