### PR TITLE
feat: Short circuit on empty data

### DIFF
--- a/docs/core/data.md
+++ b/docs/core/data.md
@@ -15,12 +15,13 @@ data, or transforming its parent scope. For more information, check out the
 
 # Props
 
-| Prop      | Required | Types           | Default   | Description                              |
-| --------- | -------- | --------------- | --------- | ---------------------------------------- |
-| data      | false    | [Array, Object] | undefined | Some supported data structure            |
-| format    | false    | String          | undefined | Format of data structure                 |
-| transform | false    | [Array, Object] | undefined | Transformation(s) to be applied          |
-| dataID    | false    | String          | undefined | ID for referencing from other data scope | 
+| Prop       | Required | Types           | Default   | Description                                                 |
+| ---------- | -------- | --------------- | --------- | ----------------------------------------------------------- |
+| data       | false    | [Array, Object] | undefined | Some supported data structure                               |
+| format     | false    | String          | undefined | Format of data structure                                    |
+| transform  | false    | [Array, Object] | undefined | Transformation(s) to be applied                             |
+| dataID     | false    | String          | undefined | ID for referencing from other data scope                    |
+| allowEmpty | false    | Boolean         | false     | When false, won't render children when receiving empty data | 
 
 # Usage
 

--- a/docs/core/graphic.md
+++ b/docs/core/graphic.md
@@ -13,15 +13,16 @@ components should be used outside of the Graphic component.
 
 # Props
 
-| Prop      | Required | Types           | Default   | Description                                   |
-| --------- | -------- | --------------- | --------- | --------------------------------------------- |
-| width     | true     | Number          | undefined | Width in screen pixels of graphic             |
-| height    | true     | Number          | undefined | Height in screen pixels of graphic            |
-| flip      | false    | Boolean         | true      | If true, y-coordinates run from bottom to top |
-| data      | false    | [Array, Object] | undefined | Some supported data structure                 |
-| format    | false    | String          | undefined | Format of data structure                      |
-| transform | false    | [Array, Object] | undefined | Transformation(s) to be applied               |
-| dataID    | false    | String          | undefined | ID for referencing from other data scope      |
+| Prop       | Required | Types           | Default   | Description                                                 |
+| ---------- | -------- | --------------- | --------- | ----------------------------------------------------------- |
+| width      | true     | Number          | undefined | Width in screen pixels of graphic                           |
+| height     | true     | Number          | undefined | Height in screen pixels of graphic                          |
+| flip       | false    | Boolean         | true      | If true, y-coordinates run from bottom to top               |
+| data       | false    | [Array, Object] | undefined | Some supported data structure                               |
+| format     | false    | String          | undefined | Format of data structure                                    |
+| transform  | false    | [Array, Object] | undefined | Transformation(s) to be applied                             |
+| dataID     | false    | String          | undefined | ID for referencing from other data scope                    |
+| allowEmpty | false    | Boolean         | false     | When false, won't render children when receiving empty data |
 
 # Usage
 

--- a/docs/core/section.md
+++ b/docs/core/section.md
@@ -39,16 +39,16 @@ for an in-depth explanation.
 
 ### Other props
 
-| Prop      | Required | Types                   | Default   | Description                              |
-| --------- | -------- | ----------------------- | --------- | ---------------------------------------- |
-| data      | false    | [Array, Object]         | undefined | Some supported data structure            |
-| type      | false    | String                  | 'scale'   | Type of local coordinate system          |
-| scale-x   | false    | [String, Array, Object] | undefined | Scaling of x dimension                   |
-| scale-y   | false    | [String, Array, Object] | undefined | Scaling of y dimension                   |
-| format    | false    | String                  | undefined | Format of data structure                 |
-| transform | false    | [Array, Object]         | undefined | Transformation(s) to be applied          |
-| dataID    | false    | String                  | undefined | ID for referencing from other data scope |
-
+| Prop       | Required | Types                   | Default   | Description                                                 |
+| ---------- | -------- | ----------------------- | --------- | ----------------------------------------------------------- |
+| data       | false    | [Array, Object]         | undefined | Some supported data structure                               |
+| type       | false    | String                  | 'scale'   | Type of local coordinate system                             |
+| scale-x    | false    | [String, Array, Object] | undefined | Scaling of x dimension                                      |
+| scale-y    | false    | [String, Array, Object] | undefined | Scaling of y dimension                                      |
+| format     | false    | String                  | undefined | Format of data structure                                    |
+| transform  | false    | [Array, Object]         | undefined | Transformation(s) to be applied                             |
+| dataID     | false    | String                  | undefined | ID for referencing from other data scope                    |
+| allowEmpty | false    | Boolean                 | false     | When false, won't render children when receiving empty data |
 
 The props passed to the `scale-x` and `scale-y` are [scaling options](../concepts/scaling.md) props.
 

--- a/src/classes/Data/DataInterface.js
+++ b/src/classes/Data/DataInterface.js
@@ -13,7 +13,7 @@ export default class DataInterface {
   ready (id) {
     let containerID = id || this._scope
     return this._manager.hasContainer(containerID) &&
-           this._manager.getContainer(containerID) !== undefined
+           this._manager.getContainer(containerID)
   }
 
   // Interface functions to DataContainer

--- a/src/classes/Data/calculateDomains.js
+++ b/src/classes/Data/calculateDomains.js
@@ -6,12 +6,6 @@ export default function (data, length) {
   let domains = {}
   let types = {}
 
-  if (length === 0) {
-    // Warn user if an empty dataframe was supplied
-    console.warn('Empty dataframe: ')
-    console.warn(JSON.stringify(data))
-  }
-
   for (let key in data) {
     // We will try to guess the type from the first VALID value of each column.
     // If the dataframe has < 2 valid values, we will set a dummy domain.

--- a/src/classes/Data/calculateDomains.js
+++ b/src/classes/Data/calculateDomains.js
@@ -6,6 +6,12 @@ export default function (data, length) {
   let domains = {}
   let types = {}
 
+  if (length === 0) {
+    // Warn user if an empty dataframe was supplied
+    console.warn('Empty dataframe: ')
+    console.warn(JSON.stringify(data))
+  }
+
   for (let key in data) {
     // We will try to guess the type from the first VALID value of each column.
     // If the dataframe has < 2 valid values, we will set a dummy domain.

--- a/src/components/Core/Data.vue
+++ b/src/components/Core/Data.vue
@@ -1,5 +1,8 @@
 <template>
-  <g class="transform">
+  <g
+    v-if="dataContainer !== false"
+    class="transform"
+  >
     <slot />
   </g>
 </template>

--- a/src/components/Core/Graphic.vue
+++ b/src/components/Core/Graphic.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    v-if="ready"
+    v-if="ready && dataContainer !== false"
     :width="width"
     :height="height"
     class="graphic"

--- a/src/components/Core/Section.vue
+++ b/src/components/Core/Section.vue
@@ -371,7 +371,7 @@ export default {
   },
 
   render (createElement) {
-    if (this.ready && this.allowScales) {
+    if (this.dataContainer !== false && this.ready && this.allowScales) {
       if (!this._axes) {
         let slotContent = this.getSlotContent()
 

--- a/src/mixins/Data/DataManager.js
+++ b/src/mixins/Data/DataManager.js
@@ -2,6 +2,8 @@ import DataContainer from '../../classes/Data/DataContainer.js'
 import DataInterface from '../../classes/Data/DataInterface.js'
 import applyTransformations from '../../transformations/applyTransformations.js'
 
+import isEmptyDataframe from '../../utils/isEmptyDataframe.js'
+
 export default {
   props: {
     data: {
@@ -17,6 +19,11 @@ export default {
     transform: {
       type: [Array, Object, undefined],
       default: undefined
+    },
+
+    dataID: {
+      type: [String, undefined],
+      default: undefined
     }
   },
 
@@ -29,12 +36,20 @@ export default {
   computed: {
     dataContainer () {
       if (this.data) {
+        if (isEmptyDataframe(this.data)) {
+          return false
+        }
+
         let container = new DataContainer(this.data, this.format)
         if (this.transform) {
           let transformedData = applyTransformations(
             container.getDataset(),
             this.transform
           )
+
+          if (transformedData === false) {
+            return false
+          }
 
           return Object.freeze(new DataContainer(transformedData))
         } else {
@@ -44,18 +59,8 @@ export default {
     },
 
     dataScopeID () {
-      let id
-      if (this.$attrs.id) {
-        // use id if given
-        id = this.$attrs.id
-      } else if (this.$vnode.data.staticClass) {
-        // fall back on class if no id is given
-        let elClass = this.$vnode.data.staticClass.replace(/\s+/g, '_')
-        id = elClass + '_' + this.uuid
-      } else {
-        id = '_' + this.uuid
-      }
-      return id
+      if (this.dataID) { return this.dataID }
+      return '_' + this.uuid
     }
   },
 

--- a/src/mixins/Data/DataManager.js
+++ b/src/mixins/Data/DataManager.js
@@ -24,6 +24,11 @@ export default {
     dataID: {
       type: [String, undefined],
       default: undefined
+    },
+
+    allowEmpty: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -36,7 +41,7 @@ export default {
   computed: {
     dataContainer () {
       if (this.data) {
-        if (isEmptyDataframe(this.data)) {
+        if (!this.allowEmpty && isEmptyDataframe(this.data)) {
           return false
         }
 
@@ -44,7 +49,8 @@ export default {
         if (this.transform) {
           let transformedData = applyTransformations(
             container.getDataset(),
-            this.transform
+            this.transform,
+            this.allowEmpty
           )
 
           if (transformedData === false) {

--- a/src/mixins/Data/DataProvider.js
+++ b/src/mixins/Data/DataProvider.js
@@ -2,6 +2,8 @@ import DataContainer from '../../classes/Data/DataContainer.js'
 import applyTransformations from '../../transformations/applyTransformations.js'
 import { createPropCache, createWatchers } from '../../components/Core/utils/propCache.js'
 
+import isEmptyDataframe from '../../utils/isEmptyDataframe.js'
+
 export default {
   inject: ['$$dataManager', '$$dataScope'],
 
@@ -36,12 +38,20 @@ export default {
   computed: {
     dataContainer () {
       if (this.data) {
+        if (isEmptyDataframe(this.data)) {
+          return false
+        }
+
         let container = new DataContainer(this.data, this.format)
         if (this.dataProviderCache.transform) {
           let transformedData = applyTransformations(
             container.getDataset(),
             this.dataProviderCache.transform
           )
+
+          if (transformedData === false) {
+            return false
+          }
 
           return new DataContainer(transformedData)
         } else {
@@ -55,6 +65,10 @@ export default {
           data,
           this.dataProviderCache.transform
         )
+
+        if (transformedData === false) {
+          return false
+        }
 
         return new DataContainer(transformedData)
       }

--- a/src/mixins/Data/DataProvider.js
+++ b/src/mixins/Data/DataProvider.js
@@ -26,6 +26,11 @@ export default {
     dataID: {
       type: [String, undefined],
       default: undefined
+    },
+
+    allowEmpty: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -38,7 +43,7 @@ export default {
   computed: {
     dataContainer () {
       if (this.data) {
-        if (isEmptyDataframe(this.data)) {
+        if (!this.allowEmpty && isEmptyDataframe(this.data)) {
           return false
         }
 
@@ -46,7 +51,8 @@ export default {
         if (this.dataProviderCache.transform) {
           let transformedData = applyTransformations(
             container.getDataset(),
-            this.dataProviderCache.transform
+            this.dataProviderCache.transform,
+            this.allowEmpty
           )
 
           if (transformedData === false) {
@@ -63,7 +69,8 @@ export default {
         let data = this.parentDataInterface.getDataset()
         let transformedData = applyTransformations(
           data,
-          this.dataProviderCache.transform
+          this.dataProviderCache.transform,
+          this.allowEmpty
         )
 
         if (transformedData === false) {

--- a/src/transformations/applyTransformations.js
+++ b/src/transformations/applyTransformations.js
@@ -1,5 +1,6 @@
-import applyTranformation from './applyTransformation.js'
 import cloneDeep from 'lodash.clonedeep'
+import applyTranformation from './applyTransformation.js'
+import isEmptyDataframe from '../utils/isEmptyDataframe.js'
 
 export default function (inputData, transform) {
   let data = cloneDeep(inputData)
@@ -7,11 +8,13 @@ export default function (inputData, transform) {
   if (transform.constructor === Array) {
     for (let transformation of transform) {
       data = applyTranformation(data, transformation)
+      if (isEmptyDataframe(data)) { return false }
     }
   }
 
   if (transform.constructor === Object) {
     data = applyTranformation(data, transform)
+    if (isEmptyDataframe(data)) { return false }
   }
 
   return data

--- a/src/transformations/applyTransformations.js
+++ b/src/transformations/applyTransformations.js
@@ -2,19 +2,19 @@ import cloneDeep from 'lodash.clonedeep'
 import applyTranformation from './applyTransformation.js'
 import isEmptyDataframe from '../utils/isEmptyDataframe.js'
 
-export default function (inputData, transform) {
+export default function (inputData, transform, allowEmpty) {
   let data = cloneDeep(inputData)
 
   if (transform.constructor === Array) {
     for (let transformation of transform) {
       data = applyTranformation(data, transformation)
-      if (isEmptyDataframe(data)) { return false }
+      if (!allowEmpty && isEmptyDataframe(data)) { return false }
     }
   }
 
   if (transform.constructor === Object) {
     data = applyTranformation(data, transform)
-    if (isEmptyDataframe(data)) { return false }
+    if (!allowEmpty && isEmptyDataframe(data)) { return false }
   }
 
   return data

--- a/src/utils/isEmptyDataframe.js
+++ b/src/utils/isEmptyDataframe.js
@@ -1,0 +1,44 @@
+export default function (data) {
+  let emptyData = false
+  if (data.constructor === Object) {
+    if (data.hasOwnProperty('type') && data.type === 'FeatureCollection') {
+      // GeoJSON
+      emptyData = geojsonEmpty(data)
+    } else {
+      // Column oriented
+      emptyData = colDataEmpty(data)
+    }
+  }
+
+  if (data.constructor === Array) {
+    // Row oriented
+    emptyData = rowDataEmpty(data)
+  }
+
+  if (emptyData) {
+    console.warn(`Empty dataframe: ${JSON.stringify(data)}. Not rendering children.`)
+  }
+
+  return emptyData
+}
+
+function geojsonEmpty (data) {
+  return data.features.length === 0
+}
+
+function colDataEmpty (data) {
+  if (Object.keys(data).length === 0) { return true }
+
+  for (let key in data) {
+    if (data[key].length === 0) {
+      return true
+    }
+  }
+  return false
+}
+
+function rowDataEmpty (data) {
+  if (data.length === 0) { return true }
+  if (data.length === 1) { return Object.keys(data[0]).length === 0 }
+  return false
+}

--- a/stories/index.js
+++ b/stories/index.js
@@ -29,6 +29,7 @@ import MultipleSelections from './sandbox/MultipleSelections.vue'
 import NestedSelection from './sandbox/NestedSelection.vue'
 import AteAxisScaleBug from './sandbox/AteAxisScaleBug.vue'
 import Facets from './sandbox/Facets.vue'
+import EmptyData from './sandbox/EmptyData.vue'
 
 storiesOf('Charts', module)
   .add('Scatterplot', () => (Scatterplot))
@@ -61,3 +62,4 @@ storiesOf('Sandbox', module)
   .add('Nested selection', () => (NestedSelection))
   .add('Ate axis scale bug', () => (AteAxisScaleBug))
   .add('Facets', () => (Facets))
+  .add('Empty data', () => (EmptyData))

--- a/stories/sandbox/EmptyData.vue
+++ b/stories/sandbox/EmptyData.vue
@@ -1,0 +1,26 @@
+<template>
+  <vgg-graphic
+    :width="500"
+    :height="500"
+    :data="{ a: [5, 6], b: [7, 8] }"
+    :transform="{ filter: a => a < 5 }"
+  >
+
+    <vgg-section
+      :x1="25"
+      :x2="475"
+      :y1="25"
+      :y2="475"
+      :scale-x="[0, 10]"
+      :scale-y="[0, 10]"
+    >
+
+      <vgg-point
+        :x="5"
+        :y="5"
+      />
+
+    </vgg-section>
+
+  </vgg-graphic>
+</template>


### PR DESCRIPTION
Requested by @bianchi-dy:

`<vgg-data>`, `<vgg-graphic>` and `<vgg-section>` won't render children when they get passed an empty dataframe. An 'empty dataframe', here, is NOT the same as NO DATA. So here

```
<vgg-graphic>
  <child />
</vgg-graphic>
```

`<child />` will render, but here

```
<vgg-graphic :data="{ colA: [], colB: [] }">
  <child />
</vgg-graphic>
```

or here

```
<vgg-graphic :data="{ colA: [5, 6] }" :transform="{ filter: row => row.colA < 5 }">
  <child />
</vgg-graphic>
```

`<child />` won't. 

This is to avoid the whole console from getting flooded with warnings when you are making lots of facets and facets often end up empty. It should also improve performance a bit.

This behavior can be disabled by setting the `allow-empty` prop to `true`.