### PR TITLE
fix: proxy row logic

### DIFF
--- a/src/classes/Data/DataContainer.js
+++ b/src/classes/Data/DataContainer.js
@@ -146,26 +146,18 @@ export default class {
 
   forEachRow (fn) {
     let data = this._dataset
-    let i = 0
 
-    let row = new Proxy({}, { get: (obj, prop) => {
-      if (prop in data) { return data[prop][i] }
-      throw invalidColumnError(prop)
-    } })
-
-    let prevRow = new Proxy({}, { get: (obj, prop) => {
-      if (i === 0) { return undefined }
-      if (prop in data) { return data[prop][i - 1] }
-      throw invalidColumnError(prop)
-    } })
-
-    let nextRow = new Proxy({}, { get: (obj, prop) => {
-      if (i === this._length - 1) { return undefined }
-      if (prop in data) { return data[prop][i + 1] }
-      throw invalidColumnError(prop)
-    } })
-
-    for (i = 0; i < this._length; i++) {
+    for (let i = 0; i < this._length; i++) {
+      let row = {}
+      let prevRow = {}
+      let nextRow = {}
+      for (let colName in data) {
+        row[colName] = data[colName][i]
+        prevRow[colName] = data[colName][i - 1]
+        nextRow[colName] = data[colName][i + 1]
+      }
+      if (i === 0) prevRow = undefined
+      if (i === this._length - 1) nextRow = undefined
       fn({ row, i, prevRow, nextRow })
     }
   }

--- a/src/classes/Data/DataContainer.js
+++ b/src/classes/Data/DataContainer.js
@@ -221,5 +221,3 @@ function extractGeometry (feat) {
 function extractAttributes (feat) {
   return feat.properties
 }
-
-const invalidColumnError = prop => new Error(`Invalid column name '${prop}'`)


### PR DESCRIPTION
Just figured out that the new 'Proxy' implementation in `forEachRow` actually made it impossible to use some parts of the interactivity. If you want to add a `@hover` event listener, and in the callback do something with the `row`, `prevRow` or `nextRow`, you now get a sort of empty/broken Proxy instead of the real row. So I reverted this change