### PR TITLE
feat: Classification

### DIFF
--- a/src/scales/createClassification.js
+++ b/src/scales/createClassification.js
@@ -21,7 +21,8 @@ export default function (prop, context, classificationOptions) {
     console.warn(`groupBy value '${binning.groupBy}' ignored. Don't use groupBy in classifications.`)
   }
 
-  let binningCopy = Object.assign(binning, { groupBy: column })
+  let binningCopy = JSON.parse(JSON.stringify(binning))
+  binningCopy.groupBy = column
 
   let intervalBounds = getIntervalBounds(data, binningCopy)
   let intervals = intervalBounds.length - 1
@@ -54,8 +55,8 @@ export default function (prop, context, classificationOptions) {
 
   return input => {
     if (input < intervalBounds[0] || input > intervalBounds[intervals]) { return null }
-    for (let i = 0; i < intervals - 1; i++) {
-      if (input > intervalBounds[i]) {
+    for (let i = 0; i < intervals; i++) {
+      if (input >= intervalBounds[i] && input <= intervalBounds[i + 1]) {
         if (propType === 'shape') { return scale(i.toString()) }
         if (propType !== 'shape') { return scale(i) }
       }

--- a/src/scales/createClassification.js
+++ b/src/scales/createClassification.js
@@ -1,0 +1,87 @@
+import { getIntervalBounds } from '../transformations/transformations/binning.js'
+
+import createCoordsScale from './shorthands/coords/createCoordsScale.js'
+import createColorScale from './shorthands/color/createColorScale.js'
+import createNumericScale from './shorthands/numeric/createNumericScale.js'
+import createShapeScale from './shorthands/shape/createShapeScale.js'
+
+import parseRange from './utils/parseRange.js'
+import getPropType from './utils/getPropType.js'
+import getDimension from '../utils/getDimension.js'
+
+export default function (prop, context, classificationOptions) {
+  checkClassificationOptions(classificationOptions, context.dataInterface)
+  let dataType = 'quantitative'
+  let binning = classificationOptions.binning
+  let column = classificationOptions.column
+
+  let data = context.dataInterface.getDataset()
+
+  if (binning.groupBy) {
+    console.warn(`groupBy value '${binning.groupBy}' ignored. Don't use groupBy in classifications.`)
+  }
+
+  let binningCopy = Object.assign(binning, { groupBy: column })
+
+  let intervalBounds = getIntervalBounds(data, binningCopy)
+  let intervals = intervalBounds.length - 1
+  let domain = [0, intervals - 1]
+
+  let propType = getPropType(prop)
+
+  let scale
+
+  if (propType === 'coord') {
+    let dimension = getDimension(prop)
+    let range = context.ranges[dimension]
+    range = parseRange(range, classificationOptions)
+
+    scale = createCoordsScale(prop, dataType, domain, range, classificationOptions)
+  }
+
+  if (propType === 'color') {
+    scale = createColorScale(prop, dataType, domain, classificationOptions, context)
+  }
+
+  if (propType === 'numeric') {
+    scale = createNumericScale(prop, dataType, domain, classificationOptions)
+  }
+
+  if (propType === 'shape') {
+    domain = new Array(intervals).fill(0).map((_, i) => i.toString())
+    scale = createShapeScale(prop, dataType, domain, classificationOptions)
+  }
+
+  return input => {
+    if (input < intervalBounds[0] || input > intervalBounds[intervals]) { return null }
+    for (let i = 0; i < intervals - 1; i++) {
+      if (input > intervalBounds[i]) {
+        if (propType === 'shape') { return scale(i.toString()) }
+        if (propType !== 'shape') { return scale(i) }
+      }
+    }
+  }
+}
+
+function checkClassificationOptions (classificationOptions, dataInterface) {
+  if (!classificationOptions.hasOwnProperty('binning')) {
+    throw new Error(`Missing required classification option 'binning'`)
+  }
+
+  if (!classificationOptions.hasOwnProperty('column')) {
+    throw new Error(`Missing required classification option 'column'`)
+  }
+
+  if (classificationOptions.column.constructor !== String) {
+    throw new Error(`'column' must be a String`)
+  }
+
+  if (!dataInterface.hasColumn(classificationOptions.column)) {
+    throw new Error(`Invalid classification optoins: column '${classificationOptions.domain}' not found`)
+  }
+
+  let type = dataInterface.getType(classificationOptions.column)
+  if (type !== 'quantitative') {
+    throw new Error(`Can only use classification with data type 'quantitative'. Received '${type}'`)
+  }
+}

--- a/src/scales/createScale.js
+++ b/src/scales/createScale.js
@@ -8,6 +8,7 @@ import parseRange from './utils/parseRange.js'
 import getPrimitive from './utils/getPrimitive.js'
 
 import mappableProps from './utils/mappableProps.js'
+import getPropType from './utils/getPropType.js'
 
 import getDimension from '../utils/getDimension.js'
 
@@ -22,8 +23,10 @@ export default function (prop, context, passedScalingOptions) {
     context.scaleManager
   )
 
+  let propType = getPropType(prop)
+
   // Coordinate props
-  if (['x1', 'x2', 'y1', 'y2', 'x', 'y', 'w', 'h'].includes(prop)) {
+  if (propType === 'coord') {
     domainType = getPrimitive(domainType)
     let dimension = getDimension(prop)
     let range = context.ranges[dimension]
@@ -34,7 +37,7 @@ export default function (prop, context, passedScalingOptions) {
 
   // for interval data, either continuous or ordinal behavior
   // Color props
-  if (['stroke', 'fill'].includes(prop)) {
+  if (propType === 'color') {
     // current fix: when the domain type is interval:quantitative
     // either the whole data column is retrieved to serve as domain
     // or a section of the domain is given as an array
@@ -50,11 +53,7 @@ export default function (prop, context, passedScalingOptions) {
   }
 
   // Numeric props
-  if ([
-    'width', 'height', 'fontSize', 'strokeWidth', 'size',
-    'opacity', 'strokeOpacity', 'fillOpacity',
-    'radius'
-  ].includes(prop)) {
+  if (propType === 'numeric') {
     // current fix: when the domain type is interval:quantitative
     // either the whole data column is retrieved to serve as domain
     // or a section of the domain is given as an array
@@ -69,7 +68,7 @@ export default function (prop, context, passedScalingOptions) {
     return createNumericScale(prop, domainType, domain, scalingOptions)
   }
 
-  if (['shape'].includes(prop)) {
+  if (propType === 'shape') {
     return createShapeScale(prop, domainType, domain, scalingOptions)
   }
 }

--- a/src/scales/utils/getPropType.js
+++ b/src/scales/utils/getPropType.js
@@ -1,0 +1,21 @@
+export default function (prop) {
+  if (['x1', 'x2', 'y1', 'y2', 'x', 'y', 'w', 'h'].includes(prop)) {
+    return 'coord'
+  }
+
+  if (['stroke', 'fill'].includes(prop)) {
+    return 'color'
+  }
+
+  if ([
+    'width', 'height', 'fontSize', 'strokeWidth', 'size',
+    'opacity', 'strokeOpacity', 'fillOpacity',
+    'radius'
+  ].includes(prop)) {
+    return 'numeric'
+  }
+
+  if (['shape'].includes(prop)) {
+    return 'shape'
+  }
+}

--- a/src/transformations/transformations/binning.js
+++ b/src/transformations/transformations/binning.js
@@ -2,6 +2,14 @@ import dataLength from '../utils/dataLength.js'
 import Geostats from '../utils/geoStats.js'
 
 export default function (data, binningObj) {
+  let intervalBounds = getIntervalBounds(data, binningObj)
+  let ranges = pairRange(intervalBounds)
+
+  let newData = bin(data, binningObj.groupBy, ranges)
+  return newData
+}
+
+export function getIntervalBounds (data, binningObj) {
   if (binningObj.constructor !== Object) {
     throw new Error('Binning only accepts an Object')
   }
@@ -65,10 +73,7 @@ export default function (data, binningObj) {
     ranges = binningObj.manualClasses
   }
 
-  ranges = pairRange(ranges)
-
-  let newData = bin(data, key, ranges)
-  return newData
+  return ranges
 }
 
 // Extract domain of variable of interest

--- a/stories/index.js
+++ b/stories/index.js
@@ -32,6 +32,7 @@ import Facets from './sandbox/Facets.vue'
 import DomainError from './sandbox/DomainError.vue'
 import EmptyData from './sandbox/EmptyData.vue'
 import DuplicateScales from './sandbox/DuplicateScales.vue'
+import ClassificationTest from './sandbox/ClassificationTest.vue'
 
 storiesOf('Charts', module)
   .add('Scatterplot', () => (Scatterplot))
@@ -67,3 +68,4 @@ storiesOf('Sandbox', module)
   .add('DomainError', () => (DomainError))
   .add('Empty data', () => (EmptyData))
   .add('Duplicate scales', () => (DuplicateScales))
+  .add('Classification test', () => ClassificationTest)

--- a/stories/sandbox/ClassificationTest.vue
+++ b/stories/sandbox/ClassificationTest.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <select v-model="selected">
+      <option value="">Equal Interval</option>
+      <option value="ArithmeticProgression">Arithmetic Progression</option>
+      <option value="GeometricProgression">Geometric Progression</option>
+      <option value="Quantile">Quantile</option>
+      <option value="Jenks">Jenks</option>
+    </select>
+
+    <br>
+
+    <vgg-graphic
+      :width="650"
+      :height="650"
+      :data="data"
+    >
+      <vgg-plot-title :text="title" />
+
+      <vgg-section
+        :x1="50"
+        :x2="600"
+        :y1="50"
+        :y2="600"
+      >
+
+        <vgg-map v-slot="{ row }">
+
+          <vgg-point
+            :x="{ val: row.a, scale: 'a' }"
+            :y="{ val: row.b, scale: 'b' }"
+            :fill="{ val: row.b, classification: { column: 'b', binning: { method: selected, numClasses: 5 } } }"
+          />
+        </vgg-map>
+
+      </vgg-section>
+
+    </vgg-graphic>
+
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      data: {
+        a: this.generate(100),
+        b: this.generate(100)
+      },
+      selected: ''
+    }
+  },
+  computed: {
+    title () {
+      if (this.selected === 'EqualInterval') {
+        return 'Equal Interval Classification'
+      } else if (this.selected === 'ArithmeticProgression') {
+        return 'Arithmetic Progression Classification'
+      } else if (this.selected === 'GeometricProgression') {
+        return 'Geometric Progression Classification'
+      } else {
+        return this.selected + ' Classification'
+      }
+    }
+  },
+  methods: {
+    generate (spread, str) {
+      const N = 100
+      let col = new Array(N)
+      for (let i = 0; i < N; i++) {
+        let randInt = Math.floor(Math.random() * spread)
+        if (randInt === 0) { randInt = 1 }
+        if (!str) { col[i] = randInt }
+        if (str) {
+          let alphabet = 'abcdefghijklmnopqrstuvwxyz'
+          col[i] = alphabet[randInt]
+        }
+      }
+      return col
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Resolves #129.

The syntax is basically

`{ val: ..., classification: { ... } }`

where `classification` MUST have

`{ column: ..., binning: ... }`

where binning is the same syntax as the current binning transformation, EXCLUDING the `groupBy` option.

Other possible options for classification are 

`{ type: ..., rangeMin: ..., rangeMax: ... }`

Classification is only allowed on quantitative data. Docs and legend support coming soon