### PR TITLE
Further legends fixes

### DIFF
--- a/docs/.vuepress/components/LegendLine.vue
+++ b/docs/.vuepress/components/LegendLine.vue
@@ -50,7 +50,7 @@
       :scale="'colors'"
       :font-size="10"
       :stroke-width="10"
-      :stroke="{range: ['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']}"
+      :stroke="['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']"
       :x="150"
       :y="50"
       :w="250"
@@ -60,7 +60,7 @@
       :title-font-size="12"
       orientation="horizontal"
     />
-    
+
   </vgg-graphic>
 </template>
 

--- a/docs/.vuepress/components/LegendLine.vue
+++ b/docs/.vuepress/components/LegendLine.vue
@@ -50,7 +50,7 @@
       :scale="'colors'"
       :font-size="10"
       :stroke-width="10"
-      :stroke="['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']"
+      :stroke="{range: ['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']}"
       :x="150"
       :y="50"
       :w="250"
@@ -60,7 +60,7 @@
       :title-font-size="12"
       orientation="horizontal"
     />
-
+    
   </vgg-graphic>
 </template>
 

--- a/docs/.vuepress/components/LegendSymbol.vue
+++ b/docs/.vuepress/components/LegendSymbol.vue
@@ -43,7 +43,7 @@
 
     <vgg-symbol-legend
       :scale="'a'"
-      :size="{ range: [10, 15] }"
+      :size="[10, 15]"
       title="Size"
       :title-font-size=12
       :title-padding="10"

--- a/docs/guides/legends.md
+++ b/docs/guides/legends.md
@@ -527,7 +527,7 @@ can specified with objects or arrays, i.e. `{ type: ... }` or `[ red, green, blu
 // size
 <vgg-symbol-legend
   :scale="'a'"
-  :size="{ range: [10, 15] }"
+  :size="[10, 15]"
   title="Size"
   :title-font-size=12
   :title-padding="10"
@@ -544,8 +544,8 @@ can specified with objects or arrays, i.e. `{ type: ... }` or `[ red, green, blu
 This legend uses the `stroke-width`, `opacity` and `fill` properties to elaborate
 on the values of the `trail` mark. Scales created using `vgg-scales` can be
 called as input to `scale`. Custom ranges for the output of the legend aesthetics
-can be set using objects or arrays (for categorical data), i.e. `{ range: ... }`
-or `[ <value 1>, <value 2>, <value 3>]`.
+can be set using objects, i.e. `{ range: ..., rangeMin: ... }`
+or `{ range: [ <value 1>, <value 2>, <value 3>] }`, or as arrays: `[ <value 1>, <value 2>, <value 3>]`.
 
 <CodeDemoLayout>
 

--- a/src/components/Guides/GradientLegend.vue
+++ b/src/components/Guides/GradientLegend.vue
@@ -151,8 +151,12 @@ export default {
     colors () {
       let fill; let fillOpacity; let colors = []; let l = []
 
-      for (let i = 0; i < this.legendTicks.length - 1; i++) {
-        l.push([this.legendTicks[i].value, this.legendTicks[i + 1].value])
+      if (this._domainType.includes('interval')) {
+        for (let i = 0; i < this.legendTicks.length - 1; i++) {
+          l.push([this.legendTicks[i].value, this.legendTicks[i + 1].value])
+        }
+      } else {
+        l = this.legendTicks
       }
 
       // create fill/fillOpacity scales for rectangles

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -657,7 +657,7 @@ export default {
         }
 
         if (prop === 'strokeOpacity' || prop === 'fillOpacity' || prop === 'opacity') {
-          scaleOptions.range = scaleBasis.range ? scaleBasis.range : [0, 1]
+          scaleOptions.range = scaleBasis.range ? scaleBasis.range : scaleBasis.constructor === Array ? scaleBasis : [0, 1]
         } else if (prop === 'stroke' || prop === 'fill' || prop === 'shape') {
           if (scaleBasis.type) {
             scaleOptions.type = scaleBasis.type
@@ -665,13 +665,15 @@ export default {
 
           if (scaleBasis.range) {
             if (prop === 'stroke' || prop === 'fill') {
-              scaleOptions.ranges = scaleBasis.range ? scaleBasis.range : (this._domainType === 'categorical' || this._domainType.includes('interval')) ? 'category10' : 'blues'
+              scaleOptions.range = scaleBasis.range ? scaleBasis.range : (this._domainType === 'categorical' || this._domainType.includes('interval')) ? 'category10' : 'blues'
             } else {
-              scaleOptions.ranges = scaleBasis.range ? scaleBasis.range : ['circle', 'square']
+              scaleOptions.range = scaleBasis.range ? scaleBasis.range : ['circle', 'square']
             }
+          } else if (scaleBasis.constructor === Array) {
+            scaleOptions.range = scaleBasis
           }
         } else if (prop === 'size' || prop === 'radius' || prop === 'strokeWidth') {
-          scaleOptions.range = scaleBasis.range ? scaleBasis.range : [0, 10]
+          scaleOptions.range = scaleBasis.range ? scaleBasis.range : scaleBasis.constructor === Array ? scaleBasis : [0, 10]
         }
 
         // custom scales with # signs only apply to domains

--- a/stories/sandbox/Scatterplot.vue
+++ b/stories/sandbox/Scatterplot.vue
@@ -83,7 +83,7 @@
 
       <vgg-symbol-legend
         :scale="{ domain: 'dependent'}"
-        :size="{ range: [0, 10] }"
+        :size="[0, 10]"
         :tick-count="8"
         position="br"
         title="Size"

--- a/stories/sandbox/TrailMark.vue
+++ b/stories/sandbox/TrailMark.vue
@@ -57,7 +57,7 @@
       :scale="'colors'"
       :font-size="10"
       :stroke-width="8"
-      :stroke="{ range: ['red', 'green', 'blue', 'purple'] }"
+      :stroke="['red', 'green', 'blue', 'purple']"
       :x="600"
       :y="100"
       shape="line"


### PR DESCRIPTION
**Changes in this PR**

- Resolved error in scatterplot2 (sandbox); this was due to some incorrect type checking in `Gradient Legend`

![Screenshot from 2019-04-18 13-45-19](https://user-images.githubusercontent.com/44487900/56378136-b07d3200-623e-11e9-9535-bc0b28004f48.png)

- Legend aesthetics like `fill`, `size` now accept arrays directly as inputs (they don't need to be in `range` objects anymore to be valid. Updated docs for this as well. In cases where user wants to use other `range` scaling attributes like `rangeMax` or `rangeMin`, they still need to input the target range plus these as an object.

```js
:stroke="['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']" 
 
OR
      
:stroke="{range: ['#F8766D', '#7CAE00', '#00BFC4', '#C77CFF', 'orange']}" 
```
<img width="318" alt="Screenshot 2019-04-19 at 1 00 17 AM" src="https://user-images.githubusercontent.com/44487900/56378180-d6a2d200-623e-11e9-8e30-47881eb5146e.png">

- All specifications for `range` have been standardized from `ranges` or `range` to **just `range`**
