### PR TITLE
Legends checker

### DIFF
--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -38,7 +38,6 @@
       >
         <g v-if="orientation==='vertical'">
           <vgg-data :data="aesthetics">
-            <text> {{ aesthetics[0] }}</text>
             <vgg-map v-slot="{ row }">
               <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
@@ -47,7 +46,7 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.05"
               />
             </vgg-map>
           </vgg-data>
@@ -92,7 +91,7 @@
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
+                :opacity="row.fillOpacity"
               />
             </vgg-map>
           </vgg-data>

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -38,18 +38,20 @@
       >
         <g v-if="orientation==='vertical'">
           <vgg-data :data="aesthetics">
+            <text> {{ aesthetics[0] }}</text>
             <vgg-map v-slot="{ row }">
+              <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
                 :x1="positionElements.rectangle.x1"
                 :x2="positionElements.rectangle.x2"
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity >= 0 ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
               />
             </vgg-map>
           </vgg-data>
-          <text> {{ aesthetics }}</text>
+
           <vgg-data :data="ticks">
             <vgg-map v-slot="{ row }">
               <vgg-label
@@ -83,13 +85,14 @@
         </g><g v-else>
           <vgg-data :data="aesthetics">
             <vgg-map v-slot="{ row }">
+              <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
                 :x1="row.start"
                 :x2="row.end"
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
               />
             </vgg-map>
           </vgg-data>
@@ -227,7 +230,7 @@ export default {
           this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       }
-      console.log(aesthetics)
+
       return aesthetics
     },
 

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -45,11 +45,11 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity >= 0 ? row.fillOpacity : legendOpacity"
               />
             </vgg-map>
           </vgg-data>
-
+          <text> {{ aesthetics }}</text>
           <vgg-data :data="ticks">
             <vgg-map v-slot="{ row }">
               <vgg-label
@@ -203,7 +203,7 @@ export default {
             aesthetics[i].fillOpacity = this._domainType.includes('interval') ? fillOpacity(valueDomain[i]) : fillOpacity(valueDomain[i].value)
           }
 
-          this.checkValidity([aesthetics[i].fill, aesthetics[i].fillOpacity], valueDomain[i])
+          this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       } else {
         for (let i = valueDomain.length - 1; i >= 0; i--) {
@@ -224,10 +224,10 @@ export default {
             aesthetics[i].fillOpacity = this._domainType.includes('interval') ? fillOpacity(valueDomain[i]) : fillOpacity(valueDomain[i].value)
           }
 
-          this.checkValidity([aesthetics[i].fill, aesthetics[i].fillOpacity], valueDomain[i])
+          this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       }
-
+      console.log(aesthetics)
       return aesthetics
     },
 
@@ -276,17 +276,8 @@ export default {
 
       return ticks
     }
-  },
-
-  methods: {
-    checkValidity (objects, indexItem) {
-      for (let i = 0; i < objects.length; i++) {
-        if (!objects[i]) {
-          throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the gradient legend')
-        }
-      }
-    }
   }
+
 }
 </script>
 this.legendCache.fillOpacity

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -46,7 +46,7 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.05"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.001"
               />
             </vgg-map>
           </vgg-data>
@@ -91,7 +91,7 @@
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.001"
               />
             </vgg-map>
           </vgg-data>

--- a/src/components/Guides/GradientLegend.vue
+++ b/src/components/Guides/GradientLegend.vue
@@ -188,7 +188,7 @@ export default {
 
             let offset = 100 - (this._domainType.includes('interval') ? sectionScale(l[i - 1][0]) : sectionScale(l[i - 1].value))
 
-            this.checkValidity([color, opacity], l[i - 1])
+            this.checkValidity(color, opacity, l[i - 1])
 
             colors.push({ color, offset, opacity })
           }
@@ -202,7 +202,7 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i]) : fillOpacity(l[i].value)
             }
 
-            this.checkValidity([color, opacity], l[i])
+            this.checkValidity(color, opacity, l[i])
 
             let offset = this._domainType.includes('interval') ? sectionScale(l[i][0]) : sectionScale(l[i].value)
             colors.push({ color, offset, opacity })
@@ -219,7 +219,7 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i]) : fillOpacity(l[i].value)
             }
 
-            this.checkValidity([color, opacity], l[i])
+            this.checkValidity(color, opacity, l[i])
             let offset = this._domainType.includes('interval') ? sectionScale(l[i][0]) : sectionScale(l[i].value)
             colors.push({ color, offset, opacity })
           }
@@ -233,7 +233,8 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i - 1]) : fillOpacity(l[i - 1].value)
             }
 
-            this.checkValidity([color, opacity], l[i - 1])
+            this.checkValidity(color, opacity, l[i - 1])
+
             let offset = 100 - (this._domainType.includes('interval') ? sectionScale(l[i - 1][0]) : sectionScale(l[i - 1].value))
             colors.push({ color, offset, opacity })
           }
@@ -279,16 +280,6 @@ export default {
       }
 
       return boxes
-    }
-  },
-
-  methods: {
-    checkValidity (objects, indexItem) {
-      for (let i = 0; i < objects.length; i++) {
-        if (!objects[i]) {
-          throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the gradient legend')
-        }
-      }
     }
   }
 }

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -699,6 +699,16 @@ export default {
         return false
       }
       return true
+    },
+
+    checkValidity (color, opacity, indexItem) {
+      if (!this.checkValidColor(color)) {
+        throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' legend')
+      }
+
+      if (isNaN(opacity)) {
+        throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' discrete legend')
+      }
     }
   }
 }

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -685,7 +685,7 @@ export default {
       }
     },
 
-    // CSS color recognition for color reliant properties
+    // checks if input is a valid RGB, HEX or color name
     checkValidColor (color) {
       let e = document.getElementById('divValidColor')
       if (!e) {
@@ -701,6 +701,8 @@ export default {
       return true
     },
 
+    // Checks if fill, fillOpacity scales have returned valid values
+    // If no, then warning is thrown to inform user which tickValue caused the undefined value
     checkValidity (color, opacity, indexItem) {
       if (!this.checkValidColor(color)) {
         throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' legend')

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -96,13 +96,13 @@
           :fill-opacity="{ range: [0, 1]}"
           :h="400"
           :show-first="false"
-          :show-last="false"
+
           title="Discrete"
           position="tl"
           fill="blue"
         />
 
-        <vgg-gradient-legend
+        <!-- <vgg-gradient-legend
           :scale="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60], [60, 100]]"
           :tick-values="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60]]"
           :title-padding="2"
@@ -110,7 +110,7 @@
           position="tr"
           title="Gradient"
           fill="blue"
-        />
+        /> -->
 
       </vgg-data>
     </vgg-graphic>

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -96,13 +96,13 @@
           :fill-opacity="{ range: [0, 1]}"
           :h="400"
           :show-first="false"
-
+          :show-last="false"
           title="Discrete"
           position="tl"
           fill="blue"
         />
 
-        <!-- <vgg-gradient-legend
+        <vgg-gradient-legend
           :scale="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60], [60, 100]]"
           :tick-values="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60]]"
           :title-padding="2"
@@ -110,7 +110,7 @@
           position="tr"
           title="Gradient"
           fill="blue"
-        /> -->
+        />
 
       </vgg-data>
     </vgg-graphic>

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -41,7 +41,7 @@
               :y1="0"
               :y2="{ val: row.binCount }"
               :fill="'blue'"
-              :opacity="{ val: row.bins, scale: { domain: 'bins' } }"
+              :opacity="{ val: row.bins, scale: { domain: 'bins', range: [0.001, 1] } }"
             />
 
             <!-- <vgg-rectangle
@@ -93,7 +93,7 @@
           :scale="'bins'"
           :font-size="10"
           :title-padding="2"
-          :fill-opacity="{ range: [0.05, 1]}"
+          :fill-opacity="{ range: [0.001, 1]}"
           :h="400"
           :show-last="false"
           title="Discrete"

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -19,7 +19,7 @@
       <vgg-data
         :transform="[
           { rename: { a: 'apple', b: 'banana', d: 'durian' } },
-          { binning: { groupBy: 'apple', method: selected, numClasses: 20 } },
+          { binning: { groupBy: 'apple', method: selected, numClasses: 30 } },
           { summarise: { binCount: { apple: 'count' } } }
         ]"
       >
@@ -93,9 +93,8 @@
           :scale="'bins'"
           :font-size="10"
           :title-padding="2"
-          :fill-opacity="{ range: [0, 1]}"
+          :fill-opacity="{ range: [0.05, 1]}"
           :h="400"
-          :show-first="false"
           :show-last="false"
           title="Discrete"
           position="tl"


### PR DESCRIPTION
In response to this bug in `BinningTest` on `master` 
![Screenshot from 2019-04-26 10-03-05](https://user-images.githubusercontent.com/44487900/56798009-96e47780-6848-11e9-8e55-773ab1bb6503.png)

**Changes in this PR**

- Fixed implementation of `checkValidity` for `fill, fillOpacity`, which was causing above bug. `checkValidity` determines which tick is causing either `fill` or `fillOpacity` values obtained from the scale generated by `scale` and these props to return NaN or undefined values.

- `checkValidity` moved to `BaseLegend.js` as it is used in both Discrete and Gradient Legends

- Set default min value for `fillOpacity` for discrete legend rectangles to 0.01 – 0 is a 'falsy' value, and hence the opacity for that particular rectangle becomes 1. Not a good idea to set the min value to 0.05 since certain scales return values lower than 0.05 for the second rectangle's `fillOpacity` value.