### PR TITLE
Legends classification

### DIFF
--- a/docs/.vuepress/components/LegendClassification.vue
+++ b/docs/.vuepress/components/LegendClassification.vue
@@ -1,0 +1,72 @@
+<template>
+  <div>
+    <vgg-graphic
+      :width="250"
+      :height="200"
+      :data="data"
+    >
+      <vgg-discrete-legend
+        :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
+        :fill="{type:'reds'}"
+        :position="'center'"
+        :h="50"
+        :w='200'
+        orientation="horizontal"
+      />
+
+      <vgg-gradient-legend
+        :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
+        :fill="{type:'reds'}"
+        :position="'tc'"
+        :h="50"
+        :w='200'
+        orientation="horizontal"
+      />
+
+    </vgg-graphic>
+
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      data: {
+        a: this.generate(100),
+        b: this.generate(100)
+      },
+      selected: ''
+    }
+  },
+  computed: {
+    title () {
+      if (this.selected === 'EqualInterval') {
+        return 'Equal Interval Classification'
+      } else if (this.selected === 'ArithmeticProgression') {
+        return 'Arithmetic Progression Classification'
+      } else if (this.selected === 'GeometricProgression') {
+        return 'Geometric Progression Classification'
+      } else {
+        return this.selected + ' Classification'
+      }
+    }
+  },
+  methods: {
+    generate (spread, str) {
+      const N = 100
+      let col = new Array(N)
+      for (let i = 0; i < N; i++) {
+        let randInt = Math.floor(Math.random() * spread)
+        if (randInt === 0) { randInt = 1 }
+        if (!str) { col[i] = randInt }
+        if (str) {
+          let alphabet = 'abcdefghijklmnopqrstuvwxyz'
+          col[i] = alphabet[randInt]
+        }
+      }
+      return col
+    }
+  }
+}
+</script>

--- a/docs/guides/legends.md
+++ b/docs/guides/legends.md
@@ -413,7 +413,7 @@ need to be specified in the `classification` object as seen below.
 ```html
 <vgg-discrete-legend
   :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
-  :fill="{type:'blues'}"
+  :fill="{type:'reds'}"
   :position="'center'"
   :h="50"
   :w='200'
@@ -422,8 +422,7 @@ need to be specified in the `classification` object as seen below.
 
 <vgg-gradient-legend
   :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
-  :fill-opacity="{ range: [0.001, 1]}"
-  :fill="'blue'"
+  :fill="{type:'reds'}"
   :position="'tc'"
   :h="50"
   :w='200'

--- a/docs/guides/legends.md
+++ b/docs/guides/legends.md
@@ -89,7 +89,8 @@ Even if different domains are given per aesthetic, the legend will follow that w
 
 | Prop   | Required | Regular types           | Default   | Description                                               |
 | ------ | -------- | ----------------------- | --------- | --------------------------------------------------------- |
-| scale  | true     | [Array, String, Object] | undefined | Domain of values visualised by the legend; this can be variable name |
+| scale  | true     | [Array, String, Object] | undefined | Domain of values visualised by the legend; this can be the variable name |
+| classification  | false     | Object | undefined | Domain of values visualised by the legend; use only either scale or classification |
 | orientation   | false    | String               | 'vertical'     | orientation of legend (vertical/horizontal)|
 | flip   | false    | Boolean               | false     | flip order of legend labels; if true, shows decreasing order                        |
 | flip-numbers   | false    | Boolean               | false     | flip placement of numbers and gradient section                        |
@@ -115,6 +116,10 @@ the input must be an object, and the target domain of the legend must be listed 
 // OR
 
 :scale="[[0, 10], [10, 20], [20, 40], [40, 60], [60, 100]]"
+
+// OR
+
+:classification="{ column: <variable>, binning: { method: <binning method>, numClasses: <positive integer> } }"
 ```
 
 <CodeDemoLayout>
@@ -360,9 +365,8 @@ see [Concepts > Scaling](../concepts/scaling.md).
 
 ### Rendering
 
-To render a legend, at bare minimum the `scale` prop must be provided. For discrete
-and gradient legends, the default encoding is set to `fill`, using the `'blues'` color
-scale. For `vgg-symbol-legend` specifically, the default shape is `circle`, with `stroke`
+To render a legend, at bare minimum the `scale` (or `classification`) prop must be provided. For discrete and gradient legends, the default encoding is set to `fill`, using the `'blues'` color scale.
+For `vgg-symbol-legend` specifically, the default shape is `circle`, with `stroke`
 set to `'black'` and `fill` set to `'none'`.
 
 <CodeDemoLayout>
@@ -392,6 +396,38 @@ set to `'black'` and `fill` set to `'none'`.
   position="right"
   :h="110"
   :w="50"
+/>
+```
+</CodeLayout>
+
+</CodeDemoLayout>
+
+When specifying the `domain` that the legend maps to, only `scale` or `classification` may be used at any given time. The same aesthetic properties apply when using `classification` instead of `legends`. However, `column` and `binning`
+need to be specified in the `classification` object as seen below.
+
+<CodeDemoLayout>
+
+<LegendClassification/>
+
+<CodeLayout>
+```html
+<vgg-discrete-legend
+  :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
+  :fill="{type:'blues'}"
+  :position="'center'"
+  :h="50"
+  :w='200'
+  orientation="horizontal"
+/>
+
+<vgg-gradient-legend
+  :classification="{ column: 'b', binning: { method: 'Jenks', numClasses: 5 } }"
+  :fill-opacity="{ range: [0.001, 1]}"
+  :fill="'blue'"
+  :position="'tc'"
+  :h="50"
+  :w='200'
+  orientation="horizontal"
 />
 ```
 </CodeLayout>

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -38,7 +38,6 @@
       >
         <g v-if="orientation==='vertical'">
           <vgg-data :data="aesthetics">
-            <text> {{ aesthetics[0] }}</text>
             <vgg-map v-slot="{ row }">
               <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
@@ -47,7 +46,7 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.05"
               />
             </vgg-map>
           </vgg-data>
@@ -92,7 +91,7 @@
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
+                :opacity="row.fillOpacity"
               />
             </vgg-map>
           </vgg-data>

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -38,18 +38,20 @@
       >
         <g v-if="orientation==='vertical'">
           <vgg-data :data="aesthetics">
+            <text> {{ aesthetics[0] }}</text>
             <vgg-map v-slot="{ row }">
+              <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
                 :x1="positionElements.rectangle.x1"
                 :x2="positionElements.rectangle.x2"
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity >= 0 ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
               />
             </vgg-map>
           </vgg-data>
-          <text> {{ aesthetics }}</text>
+
           <vgg-data :data="ticks">
             <vgg-map v-slot="{ row }">
               <vgg-label
@@ -83,13 +85,14 @@
         </g><g v-else>
           <vgg-data :data="aesthetics">
             <vgg-map v-slot="{ row }">
+              <!-- We use a default value for opacity because if row.fillOpacity is 0, then it registers as false -->
               <vgg-rectangle
                 :x1="row.start"
                 :x2="row.end"
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.000001"
               />
             </vgg-map>
           </vgg-data>
@@ -227,7 +230,7 @@ export default {
           this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       }
-      console.log(aesthetics)
+
       return aesthetics
     },
 

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -170,13 +170,20 @@ export default {
         domain = [0, valueDomain.length - 1]
       }
 
-      sectionScale = this._domainType.includes('interval') ? this.sectionScale(domain) : 100 / this.legendTicks.length
+      // sectionScale = this._domainType.includes('interval') ? this.sectionScale(domain) : 100 / this.legendTicks.length
+      if (this._domainType.includes('interval')) {
+        sectionScale = this.sectionScale(domain)
+      } else if (this.legendCache.classification) {
+        sectionScale = this.sectionScale([this._parsedScalingOptions.boundaries[0], this._parsedScalingOptions.boundaries[this._parsedScalingOptions.boundaries.length - 1]])
+      } else {
+        sectionScale = 100 / this.legendTicks.length
+      }
 
       // create fill/fillOpacity scales for rectangles
       _fill = this.legendCache.fill || 'none'
 
       if (!this.checkValidColor(_fill)) {
-        if (this.legendCache.scale && !this.legendCache.classification) {
+        if (this.legendCache.scale && this.legendCache.classification) {
           throw new Error('Invalid input: Use only `scale` or `classification`')
         } else if (this.legendCache.scale && !this.legendCache.classification) {
           fill = this.generateScale('fill', _fill)
@@ -186,7 +193,7 @@ export default {
           fillOpacity = 1
         }
       } else if (this.legendCache.fillOpacity && this.checkValidColor(_fill)) {
-        if (this.legendCache.scale && !this.legendCache.classification) {
+        if (this.legendCache.scale && this.legendCache.classification) {
           throw new Error('Invalid input: Use only `scale` or `classification`')
         } else if (this.legendCache.scale && !this.legendCache.classification) {
           fill = _fill
@@ -207,6 +214,8 @@ export default {
 
           if (this._domainType.includes('interval')) {
             aesthetics[i].end = sectionScale(valueDomain[i][1])
+          } else if (this.legendCache.classification) {
+            aesthetics[i].end = sectionScale(valueDomain[i].value)
           } else {
             aesthetics[i].end = sectionScale * (i + 1)
           }
@@ -228,6 +237,8 @@ export default {
 
           if (this._domainType.includes('interval')) {
             aesthetics[i].end = 100 - sectionScale(valueDomain[i][0])
+          } else if (this.legendCache.classification) {
+            aesthetics[i].end = sectionScale(valueDomain[i].value)
           } else {
             aesthetics[i].end = 100 - (sectionScale * i)
           }
@@ -252,7 +263,15 @@ export default {
       let l = this.legendTicks
       let start = 0; let end = 0; let location
       let domain = this._domainType.includes('interval') ? [this.legendTicks[0].value, this.legendTicks[this.legendTicks.length - 1].value] : this._domain
-      let sectionScale = this._domainType.includes('interval') ? this.sectionScale(domain) : 100 / l.length
+      let sectionScale
+      if (this._domainType.includes('interval')) {
+        sectionScale = this.sectionScale(domain)
+      } else if (this.legendCache.classification) {
+        sectionScale = this.sectionScale([this._parsedScalingOptions.boundaries[0], this._parsedScalingOptions.boundaries[this._parsedScalingOptions.boundaries.length - 1]])
+      } else {
+        sectionScale = 100 / l.length
+      }
+      // let sectionScale = this._domainType.includes('interval') ? this.sectionScale(domain) : 100 / l.length
 
       if (!this.showFirst) {
         l.shift()
@@ -265,27 +284,27 @@ export default {
       if (!this.flip) {
         for (let i = 0; i < l.length; i++) {
           start = end
-          if (this._domainType.includes('interval')) {
+          if (this._domainType.includes('interval') || this.legendCache.classification) {
             end = sectionScale(l[i].value)
           } else {
             end += sectionScale
           }
 
-          location = this._domainType.includes('interval') ? end : (start + end) / 2
+          location = this._domainType.includes('interval') || this.legendCache.classification ? end : (start + end) / 2
           ticks.push({ location: location, label: l[i].label })
         }
       } else {
         for (let i = l.length - 1; i >= 0; i--) {
           start = end
 
-          if (this._domainType.includes('interval')) {
+          if (this._domainType.includes('interval') || this.legendCache.classification) {
             end = 100 - sectionScale(l[i].value)
           } else {
             end = 100 - sectionScale * i
           }
 
           // end = 100 - sectionScale(l[i].value)
-          location = this._domainType.includes('interval') ? end : (start + end) / 2
+          location = this._domainType.includes('interval') || this.legendCache.classification ? end : (start + end) / 2
           ticks.push({ location: location, label: l[i].label })
         }
       }

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -163,7 +163,6 @@ export default {
         for (let i = 0; i < this.legendTicks.length - 1; i++) {
           valueDomain.push([this.legendTicks[i].value, this.legendTicks[i + 1].value])
         }
-        // valueDomain = this.tickValues
         domain = [valueDomain[0][0], valueDomain[valueDomain.length - 1][1]]
       } else {
         valueDomain = this.legendTicks

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -176,11 +176,25 @@ export default {
       _fill = this.legendCache.fill || 'none'
 
       if (!this.checkValidColor(_fill)) {
-        fill = this.generateScale('fill', _fill)
-        fillOpacity = 1
+        if (this.legendCache.scale && !this.legendCache.classification) {
+          throw new Error('Invalid input: Use only `scale` or `classification`')
+        } else if (this.legendCache.scale && !this.legendCache.classification) {
+          fill = this.generateScale('fill', _fill)
+          fillOpacity = 1
+        } else if (!this.legendCache.scale && this.legendCache.classification) {
+          fill = this.generateClassification('fill', _fill)
+          fillOpacity = 1
+        }
       } else if (this.legendCache.fillOpacity && this.checkValidColor(_fill)) {
-        fill = _fill
-        fillOpacity = this.generateScale('fillOpacity', this.legendCache.fillOpacity)
+        if (this.legendCache.scale && !this.legendCache.classification) {
+          throw new Error('Invalid input: Use only `scale` or `classification`')
+        } else if (this.legendCache.scale && !this.legendCache.classification) {
+          fill = _fill
+          fillOpacity = this.generateScale('fillOpacity', this.legendCache.fillOpacity)
+        } else if (!this.legendCache.scale && this.legendCache.classification) {
+          fill = _fill
+          fillOpacity = this.generateClassification('fillOpacity', this.legendCache.fillOpacity)
+        }
       } else {
         throw new Error('If `fill` is set to a color (HSL, RGB or CSS value), then `fillOpacity` must be specified to create the legend')
       }

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -45,11 +45,11 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : legendOpacity"
+                :opacity="row.fillOpacity >= 0 ? row.fillOpacity : legendOpacity"
               />
             </vgg-map>
           </vgg-data>
-
+          <text> {{ aesthetics }}</text>
           <vgg-data :data="ticks">
             <vgg-map v-slot="{ row }">
               <vgg-label
@@ -203,7 +203,7 @@ export default {
             aesthetics[i].fillOpacity = this._domainType.includes('interval') ? fillOpacity(valueDomain[i]) : fillOpacity(valueDomain[i].value)
           }
 
-          this.checkValidity([aesthetics[i].fill, aesthetics[i].fillOpacity], valueDomain[i])
+          this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       } else {
         for (let i = valueDomain.length - 1; i >= 0; i--) {
@@ -224,10 +224,10 @@ export default {
             aesthetics[i].fillOpacity = this._domainType.includes('interval') ? fillOpacity(valueDomain[i]) : fillOpacity(valueDomain[i].value)
           }
 
-          this.checkValidity([aesthetics[i].fill, aesthetics[i].fillOpacity], valueDomain[i])
+          this.checkValidity(aesthetics[i].fill, aesthetics[i].fillOpacity, valueDomain[i])
         }
       }
-
+      console.log(aesthetics)
       return aesthetics
     },
 
@@ -276,17 +276,8 @@ export default {
 
       return ticks
     }
-  },
-
-  methods: {
-    checkValidity (objects, indexItem) {
-      for (let i = 0; i < objects.length; i++) {
-        if (!objects[i]) {
-          throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the gradient legend')
-        }
-      }
-    }
   }
+
 }
 </script>
 this.legendCache.fillOpacity

--- a/src/components/Guides/DiscreteLegend.vue
+++ b/src/components/Guides/DiscreteLegend.vue
@@ -46,7 +46,7 @@
                 :y1="row.start"
                 :y2="row.end"
                 :fill="row.fill"
-                :opacity="row.fillOpacity ? row.fillOpacity : 0.05"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.001"
               />
             </vgg-map>
           </vgg-data>
@@ -91,7 +91,7 @@
                 :y1="positionElements.rectangle.y1"
                 :y2="positionElements.rectangle.y2"
                 :fill="row.fill"
-                :opacity="row.fillOpacity"
+                :opacity="row.fillOpacity ? row.fillOpacity : 0.001"
               />
             </vgg-map>
           </vgg-data>

--- a/src/components/Guides/GradientLegend.vue
+++ b/src/components/Guides/GradientLegend.vue
@@ -188,7 +188,7 @@ export default {
 
             let offset = 100 - (this._domainType.includes('interval') ? sectionScale(l[i - 1][0]) : sectionScale(l[i - 1].value))
 
-            this.checkValidity([color, opacity], l[i - 1])
+            this.checkValidity(color, opacity, l[i - 1])
 
             colors.push({ color, offset, opacity })
           }
@@ -202,7 +202,7 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i]) : fillOpacity(l[i].value)
             }
 
-            this.checkValidity([color, opacity], l[i])
+            this.checkValidity(color, opacity, l[i])
 
             let offset = this._domainType.includes('interval') ? sectionScale(l[i][0]) : sectionScale(l[i].value)
             colors.push({ color, offset, opacity })
@@ -219,7 +219,7 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i]) : fillOpacity(l[i].value)
             }
 
-            this.checkValidity([color, opacity], l[i])
+            this.checkValidity(color, opacity, l[i])
             let offset = this._domainType.includes('interval') ? sectionScale(l[i][0]) : sectionScale(l[i].value)
             colors.push({ color, offset, opacity })
           }
@@ -233,7 +233,8 @@ export default {
               opacity = this._domainType.includes('interval') ? fillOpacity(l[i - 1]) : fillOpacity(l[i - 1].value)
             }
 
-            this.checkValidity([color, opacity], l[i - 1])
+            this.checkValidity(color, opacity, l[i - 1])
+
             let offset = 100 - (this._domainType.includes('interval') ? sectionScale(l[i - 1][0]) : sectionScale(l[i - 1].value))
             colors.push({ color, offset, opacity })
           }
@@ -279,16 +280,6 @@ export default {
       }
 
       return boxes
-    }
-  },
-
-  methods: {
-    checkValidity (objects, indexItem) {
-      for (let i = 0; i < objects.length; i++) {
-        if (!objects[i]) {
-          throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the gradient legend')
-        }
-      }
     }
   }
 }

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -66,6 +66,11 @@ export default {
       required: true
     },
 
+    classification: {
+      type: [Array, String, Object, undefined],
+      default: undefined
+    },
+
     format: {
       type: [String, Function, undefined],
       default: undefined

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -699,6 +699,16 @@ export default {
         return false
       }
       return true
+    },
+
+    checkValidity (color, opacity, indexItem) {
+      if (!this.checkValidColor(color)) {
+        throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' legend')
+      }
+
+      if (isNaN(opacity)) {
+        throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' discrete legend')
+      }
     }
   }
 }

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -10,6 +10,7 @@ import { createPropCache, createWatchers } from '../../components/Core/utils/pro
 
 import parseScaleOptions from '../../scales/utils/parseScaleOptions.js'
 import createScale from '../../scales/createScale.js'
+import createClassification from '../../scales/createClassification.js'
 import defaultFormat from './utils/defaultFormat.js'
 import ticksFromIntervals from './utils/ticksFromIntervals.js'
 
@@ -605,6 +606,89 @@ export default {
   methods: {
     sectionScale (domain) {
       return scaleLinear().domain(domain).range([0, 100])
+    },
+
+    generateClassification (prop, classBasis) {
+      let scaleOptions = {}
+
+      if (classBasis.constructor === Number) {
+        return () => { return classBasis }
+      // } else if (scaleBasis.constructor === Array) { // FIX THIS
+      //   return (index) => { return scaleBasis[index] }
+      } else {
+        // Domain is dependent on scale inputs
+        // Range is dependent on aesthetic inputs
+        if (this.legendCache.scale.domain) {
+          scaleOptions.domain = this.legendCache.scale.domain
+        } else {
+          scaleOptions.domain = this.legendCache.scale
+        }
+
+        if (this.legendCache.scale.domainMin) {
+          scaleOptions.domainMin = this.legendCache.scale.domainMin
+        }
+
+        if (this.legendCache.scale.domainMax) {
+          scaleOptions.domainMax = this.legendCache.scale.domainMax
+        }
+
+        if (this.legendCache.scale.domainMid) {
+          scaleOptions.domainMid = this.legendCache.scale.domainMid
+        }
+
+        if (this.legendCache.scale.order && this._domainType.includes('categorical')) {
+          scaleOptions.order = this.legendCache.scale.order
+        } else if (this.legendCache.scale.order && !this._domainType.includes('categorical')) {
+          console.warn('Data must be categorical to include `order` in `scale`')
+        }
+
+        if (this.legendCache.scale.absolute) {
+          scaleOptions.absolute = this.legendCache.scale.absolute
+        }
+
+        if (this.legendCache.scale.nice) {
+          scaleOptions.nice = this.legendCache.scale.nice
+        }
+
+        if (this.legendCache.scale.reverse) {
+          scaleOptions.reverse = this.legendCache.scale.reverse
+        }
+
+        if (scaleBasis.rangeMin) {
+          scaleOptions.rangeMin = scaleBasis.rangeMin
+        }
+
+        if (scaleBasis.rangeMax) {
+          scaleOptions.rangeMax = scaleBasis.rangeMax
+        }
+
+        if (prop === 'strokeOpacity' || prop === 'fillOpacity' || prop === 'opacity') {
+          scaleOptions.range = scaleBasis.range ? scaleBasis.range : scaleBasis.constructor === Array ? scaleBasis : [0, 1]
+        } else if (prop === 'stroke' || prop === 'fill' || prop === 'shape') {
+          if (scaleBasis.type) {
+            scaleOptions.type = scaleBasis.type
+          }
+
+          if (scaleBasis.range) {
+            if (prop === 'stroke' || prop === 'fill') {
+              scaleOptions.range = scaleBasis.range ? scaleBasis.range : (this._domainType === 'categorical' || this._domainType.includes('interval')) ? 'category10' : 'blues'
+            } else {
+              scaleOptions.range = scaleBasis.range ? scaleBasis.range : ['circle', 'square']
+            }
+          } else if (scaleBasis.constructor === Array) {
+            scaleOptions.range = scaleBasis
+          }
+        } else if (prop === 'size' || prop === 'radius' || prop === 'strokeWidth') {
+          scaleOptions.range = scaleBasis.range ? scaleBasis.range : scaleBasis.constructor === Array ? scaleBasis : [0, 10]
+        }
+
+        // custom scales with # signs only apply to domains
+        if (scaleOptions.domain.includes('#')) {
+          scaleOptions.domain = this.$$scaleManager.getScale(scaleOptions.domain)[0]
+        }
+
+        return createClassification(prop, this.context, classOptions)
+      }
     },
 
     generateScale (prop, scaleBasis) {

--- a/src/mixins/Guides/BaseLegend.js
+++ b/src/mixins/Guides/BaseLegend.js
@@ -685,7 +685,7 @@ export default {
       }
     },
 
-    // CSS color recognition for color reliant properties
+    // checks if input is a valid RGB, HEX or color name
     checkValidColor (color) {
       let e = document.getElementById('divValidColor')
       if (!e) {
@@ -701,6 +701,8 @@ export default {
       return true
     },
 
+    // Checks if fill, fillOpacity scales have returned valid values
+    // If no, then warning is thrown to inform user which tickValue caused the undefined value
     checkValidity (color, opacity, indexItem) {
       if (!this.checkValidColor(color)) {
         throw new Error('The tick value(s) ' + indexItem + ' is/are not part of the domain given to the ' + this.type + ' legend')

--- a/src/scales/createClassification.js
+++ b/src/scales/createClassification.js
@@ -14,7 +14,6 @@ export default function (prop, context, classificationOptions) {
   let dataType = 'quantitative'
   let binning = classificationOptions.binning
   let column = classificationOptions.column
-
   let data = context.dataInterface.getDataset()
 
   if (binning.groupBy) {

--- a/src/transformations/transformations/binning.js
+++ b/src/transformations/transformations/binning.js
@@ -42,7 +42,7 @@ export function getIntervalBounds (data, binningObj) {
   let geoStat = new Geostats(variableData)
 
   let ranges
-
+  console.log(method)
   // Calculate ranges to obtain bins of a specified size
   if (method === 'IntervalSize') {
     let binSize = binningObj.binSize

--- a/src/transformations/transformations/binning.js
+++ b/src/transformations/transformations/binning.js
@@ -42,7 +42,7 @@ export function getIntervalBounds (data, binningObj) {
   let geoStat = new Geostats(variableData)
 
   let ranges
-  console.log(method)
+
   // Calculate ranges to obtain bins of a specified size
   if (method === 'IntervalSize') {
     let binSize = binningObj.binSize

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -96,13 +96,13 @@
           :fill-opacity="{ range: [0, 1]}"
           :h="400"
           :show-first="false"
-          :show-last="false"
+
           title="Discrete"
           position="tl"
           fill="blue"
         />
 
-        <vgg-gradient-legend
+        <!-- <vgg-gradient-legend
           :scale="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60], [60, 100]]"
           :tick-values="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60]]"
           :title-padding="2"
@@ -110,7 +110,7 @@
           position="tr"
           title="Gradient"
           fill="blue"
-        />
+        /> -->
 
       </vgg-data>
     </vgg-graphic>

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -96,13 +96,13 @@
           :fill-opacity="{ range: [0, 1]}"
           :h="400"
           :show-first="false"
-
+          :show-last="false"
           title="Discrete"
           position="tl"
           fill="blue"
         />
 
-        <!-- <vgg-gradient-legend
+        <vgg-gradient-legend
           :scale="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60], [60, 100]]"
           :tick-values="[[0, 10], [10, 20], [20, 40], [40, 45], [45, 60]]"
           :title-padding="2"
@@ -110,7 +110,7 @@
           position="tr"
           title="Gradient"
           fill="blue"
-        /> -->
+        />
 
       </vgg-data>
     </vgg-graphic>

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -41,7 +41,7 @@
               :y1="0"
               :y2="{ val: row.binCount }"
               :fill="'blue'"
-              :opacity="{ val: row.bins, scale: { domain: 'bins' } }"
+              :opacity="{ val: row.bins, scale: { domain: 'bins', range: [0.001, 1] } }"
             />
 
             <!-- <vgg-rectangle
@@ -93,7 +93,7 @@
           :scale="'bins'"
           :font-size="10"
           :title-padding="2"
-          :fill-opacity="{ range: [0.05, 1]}"
+          :fill-opacity="{ range: [0.001, 1]}"
           :h="400"
           :show-last="false"
           title="Discrete"

--- a/stories/sandbox/BinningTest.vue
+++ b/stories/sandbox/BinningTest.vue
@@ -19,7 +19,7 @@
       <vgg-data
         :transform="[
           { rename: { a: 'apple', b: 'banana', d: 'durian' } },
-          { binning: { groupBy: 'apple', method: selected, numClasses: 20 } },
+          { binning: { groupBy: 'apple', method: selected, numClasses: 30 } },
           { summarise: { binCount: { apple: 'count' } } }
         ]"
       >
@@ -93,9 +93,8 @@
           :scale="'bins'"
           :font-size="10"
           :title-padding="2"
-          :fill-opacity="{ range: [0, 1]}"
+          :fill-opacity="{ range: [0.05, 1]}"
           :h="400"
-          :show-first="false"
           :show-last="false"
           title="Discrete"
           position="tl"

--- a/stories/sandbox/ClassificationTest.vue
+++ b/stories/sandbox/ClassificationTest.vue
@@ -38,6 +38,15 @@
           :y="50"
           orientation="horizontal"
         />
+
+        <vgg-gradient-legend
+          :classification="{ column: 'b', binning: { method: selected, numClasses: 5 } }"
+          :fill-opacity="{ range: [0.001, 1]}"
+          :fill="'blue'"
+          :y="50"
+          :x="500"
+          orientation="horizontal"
+        />
       </vgg-section>
 
 

--- a/stories/sandbox/ClassificationTest.vue
+++ b/stories/sandbox/ClassificationTest.vue
@@ -35,6 +35,10 @@
 
       </vgg-section>
 
+      <vgg-discrete-legend
+        :classification="{ column: 'b', binning: { method: selected, numClasses: 5 } }"
+        :fill="{type:'blues'}"
+        />
     </vgg-graphic>
 
   </div>

--- a/stories/sandbox/ClassificationTest.vue
+++ b/stories/sandbox/ClassificationTest.vue
@@ -32,13 +32,15 @@
             :fill="{ val: row.b, classification: { column: 'b', binning: { method: selected, numClasses: 5 } } }"
           />
         </vgg-map>
-
+        <vgg-discrete-legend
+          :classification="{ column: 'b', binning: { method: selected, numClasses: 5 } }"
+          :fill="{type:'blues'}"
+          :y="50"
+          orientation="horizontal"
+        />
       </vgg-section>
 
-      <vgg-discrete-legend
-        :classification="{ column: 'b', binning: { method: selected, numClasses: 5 } }"
-        :fill="{type:'blues'}"
-        />
+
     </vgg-graphic>
 
   </div>


### PR DESCRIPTION
**Changes in this PR**

- Either only `scale` or `classification` can be used to specify the domain a discrete or gradient legend is mapped to. An error is thrown when both are simultaneously specified.

- This works across all currently available binning methods under `classification`. Color spans and ticks are automatically formatted accdg to the spread of the resulting domain.

<img width="533" alt="Screenshot 2019-05-08 at 7 24 25 PM" src="https://user-images.githubusercontent.com/44487900/57372380-1159b380-71c8-11e9-9ee5-d1f88316f5d2.png">
<img width="533" alt="Screenshot 2019-05-08 at 7 24 30 PM" src="https://user-images.githubusercontent.com/44487900/57372382-11f24a00-71c8-11e9-8163-c6b949ad5475.png">






